### PR TITLE
add fix created date script

### DIFF
--- a/js/fixCreatedDate.js
+++ b/js/fixCreatedDate.js
@@ -1,0 +1,18 @@
+const dateLabels = document.querySelectorAll(
+  '.git-revision-date-localized-plugin-date'
+);
+
+// Only make modifications on pages with dates
+if (dateLabels.length > 0) {
+  const lastUpdate = dateLabels[0].innerHTML;
+  const created = dateLabels[1].innerHTML;
+
+  const lastUpdateDate = new Date(lastUpdate);
+  const createdDate = new Date(created);
+
+  // If the created date is after the last updated date,
+  // default to using the last updated date
+  if (lastUpdateDate < createdDate) {
+    dateLabels[1].innerHTML = lastUpdate;
+  }
+}


### PR DESCRIPTION
### Description

Add in the created dates script to fix the created dates when the git plugin cannot find them
Goes with mkdocs PR: https://github.com/papermoonio/tanssi-mkdocs/pull/13

You can verify this script works by checking the dates on the /builders/build/local/customizing-chain-specs page
