### PR TITLE
Reference to branch from variable

### DIFF
--- a/builders/build/templates/overview.md
+++ b/builders/build/templates/overview.md
@@ -106,7 +106,7 @@ To support the Tanssi protocol, it will be necessary to add [the modules](#base-
     }
     pallet_authorities_noting = {
         git = "https://github.com/moondance-labs/moonkit",
-        branch = "tanssi-polkadot-v0.9.43", default-features = false
+        branch = "{{ repository.tanssi.release_branch }}", default-features = false
     }
     ...
     ```


### PR DESCRIPTION
### Description

This PR replaces the branch references in the articles to point to a variable

### Checklist

- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
