### PR TITLE
Update Link Modal for Apps.Tanssi.Network

### DIFF
--- a/js/externalLinkModal.js
+++ b/js/externalLinkModal.js
@@ -63,7 +63,8 @@ const origin = window.location.origin;
 // We don't need to have a pop-up if the link goes to the Moonbeam Network or Moonbeam Foundation website
 const moonbeamLinks = [
   origin,
-  'https://tanssi.network'
+  'https://tanssi.network',
+  'https://apps.tanssi.network/'
 ];
 const checkIfMoonbeamLink = (href) => {
   return moonbeamLinks.some((link) => href.startsWith(link));


### PR DESCRIPTION
### Description

The Tanssi Docs Site currently warns when you try to access apps.tanssi.network. It shouldn't warn you, so I added it to the safe list.

Example: "Get Started" on the Homepage
<img width="610" alt="Screenshot 2023-11-20 at 8 49 08 PM" src="https://github.com/moondance-labs/tanssi-docs/assets/5834262/9328393b-36b7-4e46-b1e2-5896ecdfdd09">


### Checklist

- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
