### PR TITLE
Fixing broken links

### DIFF
--- a/builders/build/customize/adding-built-in-module.md
+++ b/builders/build/customize/adding-built-in-module.md
@@ -22,7 +22,7 @@ To follow the steps in this guide, you will need to have the following:
 - A healthy development environment with the Rust compiler and Cargo package manager
 - The [Tanssi repository](https://github.com/moondance-labs/tanssi){target=_blank}, cloned from GitHub
 
-You can read more about how to install the required components in the [prerequisites article](/builders/build/local/prerequisites){target=_blank}.
+You can read more about how to install the required components in the [prerequisites article](/builders/build/customize/prerequisites){target=_blank}.
 
 As this article is based on the EVM template, make sure that it compiles correctly before continuing by executing the following command:
 
@@ -194,7 +194,7 @@ container-chains/templates/frontier/node/src/chain_spec.rs
 
 The function `testnet_genesis`, presented in the following code snippet, defines the initial state for the modules included in the runtime (such as initial funded accounts, for example). After adding the Assets module, it is necessary to initialize it as well, and in the following example, its default values are defined.
 
-More about the chain specification and how to configure it will be covered in the article [Customizing Chain Specifications](/builders/build/local/customizing-chain-specs/){target=_blank}.
+More about the chain specification and how to configure it will be covered in the article [Customizing Chain Specifications](/builders/build/customize/customizing-chain-specs/){target=_blank}.
 
 ```rust hl_lines="14"
 fn testnet_genesis(

--- a/builders/build/customize/adding-custom-made-module.md
+++ b/builders/build/customize/adding-custom-made-module.md
@@ -32,7 +32,7 @@ To follow the steps in this guide, you will need to have the following:
 - Clone the [Tanssi repository](https://github.com/moondance-labs/tanssi){target=_blank} from Github
 - Rust compiler and Cargo package manager
 
-You can read more about how to install Rust and Cargo is in the [prerequisites article](/builders/build/local/prerequisites/#installing-rust){target=_blank}.
+You can read more about how to install Rust and Cargo is in the [prerequisites article](/builders/build/customize/prerequisites/#installing-rust){target=_blank}.
 
 ## Creating the Lottery Module Files {: #creating-lottery-module-files }
 

--- a/builders/build/templates/overview.md
+++ b/builders/build/templates/overview.md
@@ -45,7 +45,7 @@ More information about Tanssi's block production as a service and the interactio
 
 ## Start Building {: #getting-started }
 
-To start building on top of the provided templates, be it the [Baseline Appchain template](/build/templates/substrate){target=_blank} or the [Baseline EVM (Ethereum Virtual Machine) template](/builders/build/templates/evm){target=_blank}, the recommended approach is to fork the [Tanssi repository](https://github.com/moondance-labs/tanssi){target=_blank} and start adding [built-in modules](/builders/build/local/adding-built-in-pallet/){target=_blank} or [custom-made modules](/builders/build/local/adding-custom-made-module/){target=_blank} on top of the [latest release](https://github.com/moondance-labs/tanssi/releases/latest){target=_blank} tag. 
+To start building on top of the provided templates, be it the [Baseline Appchain template](/build/templates/substrate){target=_blank} or the [Baseline EVM (Ethereum Virtual Machine) template](/builders/build/templates/evm){target=_blank}, the recommended approach is to fork the [Tanssi repository](https://github.com/moondance-labs/tanssi){target=_blank} and start adding [built-in modules](/builders/build/customize/adding-built-in-module/){target=_blank} or [custom-made modules](/builders/build/customize/adding-custom-made-module/){target=_blank} on top of the [latest release](https://github.com/moondance-labs/tanssi/releases/latest){target=_blank} tag. 
 
 This approach comes with some advantages, such as:
 

--- a/builders/build/templates/substrate.md
+++ b/builders/build/templates/substrate.md
@@ -15,8 +15,8 @@ This section covers this basic template, what it includes, and some aspects to c
 
 Developing a Substrate-based runtime typically involves two primary steps:
 
-1. [Incorporating pre-existing Substrate built-in modules](/builders/build/local/adding-built-in-pallet/){target=_blank} into the runtime
-2. [Creating custom modules](/builders/build/local/adding-custom-made-module/){target=_blank} tailored to your specific application needs
+1. [Incorporating pre-existing Substrate built-in modules](/builders/build/customize/adding-built-in-module/){target=_blank} into the runtime
+2. [Creating custom modules](/builders/build/customize/adding-custom-made-module/){target=_blank} tailored to your specific application needs
 
 Since the provided template already includes the essential configurations for seamless integration into the Polkadot ecosystem and compatibility with the Tanssi protocol, teams interested in constructing an innovative Appchain can use this template as a starting point for adding their custom logic.
 

--- a/builders/deploy-manage/dapp/deploy.md
+++ b/builders/deploy-manage/dapp/deploy.md
@@ -120,7 +120,7 @@ Other required changes in the runtime include:
     AuraExt: cumulus_pallet_aura_ext = 24,
     ```
 
-Finally, [generate and edit](/builders/build/local/customizing-chain-specs/#editing-json-chain-specs){target=_blank} the chain specification paying special attention to: 
+Finally, [generate and edit](/builders/build/customize/customizing-chain-specs/#editing-json-chain-specs){target=_blank} the chain specification paying special attention to: 
 
 - `para_id` - within this custom flow, a pre-registered parachain id is required
 - `is_ethereum` - to `true` if exposing Ethereum compatible RPC endpoints is needed
@@ -179,8 +179,8 @@ Once the transaction has successfully gone through, your Appchain ID will be dis
 
 Before you can deploy your Appchain, you'll need to generate four configuration files:
 
-- [The raw chain specification](/builders/build/local/customizing-chain-specs/#generating-raw-specs-file){target=_blank} - a compact version of the JSON specification file, which defines the initial settings and state that all nodes participating in the network must agree on to reach consensus and produce blocks
-- [The genesis state header](/builders/build/local/customizing-chain-specs/#genesis-state){target=_blank} - defines the initial state upon which all transactions and state transitions are executed
+- [The raw chain specification](/builders/build/customize/customizing-chain-specs/#generating-raw-specs-file){target=_blank} - a compact version of the JSON specification file, which defines the initial settings and state that all nodes participating in the network must agree on to reach consensus and produce blocks
+- [The genesis state header](/builders/build/customize/customizing-chain-specs/#genesis-state){target=_blank} - defines the initial state upon which all transactions and state transitions are executed
 - [The genesis Wasm](/learn/framework/architecture/#runtime){target=_blank} - a WebAssembly (Wasm) blob that defines the runtime logic
 
 These files will automatically be generated for you based on your Appchain ID and your customized template configurations. All you need to do is click **Generate**, and the dApp will generate the required files for you.

--- a/learn/framework/modules.md
+++ b/learn/framework/modules.md
@@ -63,4 +63,4 @@ As an example of a custom module, the following code (not intended for productio
 --8<-- 'code/modules/lottery-example.rs'
 ```
 
-For more information about the step-by-step process of creating a custom-made module to the runtime, please refer to the [Adding a Custom-Made Module](/builders/build/local/adding-custom-made-module/){target=_blank} in the Builder's section.
+For more information about the step-by-step process of creating a custom-made module to the runtime, please refer to the [Adding a Custom-Made Module](/builders/build/customize/adding-custom-made-module/){target=_blank} in the Builder's section.


### PR DESCRIPTION
### Description

This PR fixes some broken links left after changing the section name local to customize, and an article name from pallet to module
Although no PR in mkdocs repo is necessary to publish this one, a related PR will be created to add the redirects

### Checklist

- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
