### PR TITLE
Add grammarly to checklist

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -5,5 +5,6 @@ Please explain the changes this PR addresses here.
 ### Checklist
 
 - [ ] I have added a label to this PR 🏷️
+- [ ] I have run my changes through Grammarly
 - [ ] If this page requires a disclaimer, I have added one
 - [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects


### PR DESCRIPTION
### Description

This PR adds grammarly to the checklist, this should be done right before a PR is submitted!

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
