### PR TITLE
Updates Transfer -> transferAllowDeath

### DIFF
--- a/.snippets/code/builders/interact/substrate-api/polkadot-js-api/basic-transactions.js
+++ b/.snippets/code/builders/interact/substrate-api/polkadot-js-api/basic-transactions.js
@@ -13,7 +13,7 @@ const main = async () => {
   const alice = keyring.addFromUri('INSERT_ALICES_PRIVATE_KEY');
 
   // Form the transaction
-  const tx = await api.tx.balances.transfer(
+  const tx = await api.tx.balances.transferAllowDeath(
     'INSERT_BOBS_ADDRESS',
     BigInt(12345)
   );

--- a/.snippets/code/builders/interact/substrate-api/polkadot-js-api/batch-transactions.js
+++ b/.snippets/code/builders/interact/substrate-api/polkadot-js-api/batch-transactions.js
@@ -14,8 +14,8 @@ const main = async () => {
 
   // Construct a list of transactions to batch
   const txs = [
-    api.tx.balances.transfer('INSERT_BOBS_ADDRESS', BigInt(12345)),
-    api.tx.balances.transfer('INSERT_CHARLEYS_ADDRESS', BigInt(12345)),
+    api.tx.balances.transferAllowDeath('INSERT_BOBS_ADDRESS', BigInt(12345)),
+    api.tx.balances.transferAllowDeath('INSERT_CHARLEYS_ADDRESS', BigInt(12345)),
   ];
 
   // Estimate the fees as RuntimeDispatchInfo, using the signer (either

--- a/.snippets/code/builders/interact/substrate-api/polkadot-js-api/payment-info.js
+++ b/.snippets/code/builders/interact/substrate-api/polkadot-js-api/payment-info.js
@@ -6,7 +6,7 @@ const main = async () => {
   const api = await ApiPromise.create({ provider: wsProvider });
 
   // Transaction to get weight information
-  const tx = api.tx.balances.transfer('INSERT_BOBS_ADDRESS', BigInt(12345));
+  const tx = api.tx.balances.transferAllowDeath('INSERT_BOBS_ADDRESS', BigInt(12345));
 
   // Get weight info
   const { partialFee, weight } = await tx.paymentInfo('INSERT_SENDERS_ADDRESS');

--- a/builders/interact/substrate-api/polkadot-js-api.md
+++ b/builders/interact/substrate-api/polkadot-js-api.md
@@ -233,7 +233,7 @@ The Polkadot.js API library can be used to send transactions to the network. For
 const alice = keyring.addFromUri('INSERT_ALICES_PRIVATE_KEY');
 
 // Form the transaction
-const tx = await api.tx.balances.transfer(
+const tx = await api.tx.balances.transferAllowDeath(
   'INSERT_BOBS_ADDRESS',
   BigInt(12345)
 );
@@ -267,7 +267,7 @@ For example, assuming you've [initialized the API](#creating-an-API-provider-ins
 
 ```javascript
 // Transaction to get weight information
-const tx = api.tx.balances.transfer('INSERT_BOBS_ADDRESS', BigInt(12345));
+const tx = api.tx.balances.transferAllowDeath('INSERT_BOBS_ADDRESS', BigInt(12345));
 
 // Get weight info
 const { partialFee, weight } = await tx.paymentInfo('INSERT_SENDERS_ADDRESS');
@@ -297,8 +297,8 @@ For example, assuming you've [initialized the API](#creating-an-API-provider-ins
 ```javascript
 // Construct a list of transactions to batch
 const txs = [
-  api.tx.balances.transfer('INSERT_BOBS_ADDRESS', BigInt(12345)),
-  api.tx.balances.transfer('INSERT_CHARLEYS_ADDRESS', BigInt(12345)),
+  api.tx.balances.transferAllowDeath('INSERT_BOBS_ADDRESS', BigInt(12345)),
+  api.tx.balances.transferAllowDeath('INSERT_CHARLEYS_ADDRESS', BigInt(12345)),
 ];
 
 // Estimate the fees as RuntimeDispatchInfo, using the signer (either


### PR DESCRIPTION
### Description

This PR updates the deprecated call balances.transfer to balances.transferAllowDeath

### Checklist

- [x] I have added a label to this PR 🏷️
- [x] If this page requires a disclaimer, I have added one
- [x] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
