### PR TITLE
Update Default Block Explorers 

### DIFF
--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/balances.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/balances.ts
@@ -24,7 +24,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://tanssi-evmexplorer.netlify.app/',
+      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/deploy.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/deploy.ts
@@ -31,7 +31,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://tanssi-evmexplorer.netlify.app/',
+      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/get.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/get.ts
@@ -25,7 +25,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://tanssi-evmexplorer.netlify.app/',
+      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/increment.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/increment.ts
@@ -31,7 +31,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://tanssi-evmexplorer.netlify.app/',
+      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/read-chain-data.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/read-chain-data.ts
@@ -24,7 +24,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://tanssi-evmexplorer.netlify.app/',
+      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/reset.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/reset.ts
@@ -31,7 +31,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://tanssi-evmexplorer.netlify.app/',
+      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/transaction.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/transaction.ts
@@ -31,7 +31,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://tanssi-evmexplorer.netlify.app/',
+      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/write-chain-data.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/write-chain-data.ts
@@ -25,7 +25,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://tanssi-evmexplorer.netlify.app/',
+      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/builders/interact/ethereum-api/dev-env/foundry.md
+++ b/builders/interact/ethereum-api/dev-env/foundry.md
@@ -179,7 +179,7 @@ Your forked instance will have 10 development accounts that are pre-funded with 
 
 ![Forking terminal screen](/images/builders/interact/ethereum-api/dev-environments/foundry/foundry-5.webp)
 
-To verify you have forked the network, you can query the latest block number and compare it to the current block number of the [demo EVM ContainerChain](https://tanssi-evmexplorer.netlify.app/){target=\_blank}.
+To verify you have forked the network, you can query the latest block number and compare it to the current block number of the [demo EVM ContainerChain](https://3001-blockscout.a.dancebox.tanssi.network/){target=\_blank}.
 
 ```bash
 curl --data '{"method":"eth_blockNumber","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST localhost:8545 

--- a/builders/interact/ethereum-api/dev-env/remix.md
+++ b/builders/interact/ethereum-api/dev-env/remix.md
@@ -119,7 +119,7 @@ Click **Confirm** and, after the transaction is complete, you will see a confirm
 
 ![Verify the reduction in account balance](/images/builders/interact/ethereum-api/dev-environments/remix/remix-14.webp)
 
-You can also look up the transaction on [your ContainerChain's explorer](https://tanssi-evmexplorer.netlify.app/){target=\_blank} to verify the transaction status.
+You can also look up the transaction on [your ContainerChain's explorer](https://3001-blockscout.a.dancebox.tanssi.network/){target=\_blank} to verify the transaction status.
 
 ![Check transaction status on block explorer for your ContainerChain](/images/builders/interact/ethereum-api/dev-environments/remix/remix-15.webp)
 

--- a/builders/interact/ethereum-api/wallets/metamask.md
+++ b/builders/interact/ethereum-api/wallets/metamask.md
@@ -75,8 +75,8 @@ Here, you can configure MetaMask for the following networks:
 |       Network Name        |               `EVM ContainerChain Dancebox`                |
 |          RPC URL          | `https://fraa-dancebox-3001-rpc.a.dancebox.tanssi.network` |
 |         Chain ID          |                           `5678`                           |
-|     Symbol (Optional)     |                           `UNIT`                           |
-| Block Explorer (Optional) |                           `N/A`                            |
+|     Symbol (Optional)     |                          `TANGO`                           |
+| Block Explorer (Optional) |    `https://3001-blockscout.a.dancebox.tanssi.network/`    |
 
 To do so, fill in the following information:
 

--- a/builders/interact/ethereum-api/wallets/subwallet.md
+++ b/builders/interact/ethereum-api/wallets/subwallet.md
@@ -50,7 +50,7 @@ On the following screen, you'll be able to provide the relevant seed phrase, pri
 To configure SubWallet for your EVM ContainerChain, press the **More Options** icon in the upper left corner. Then click **Manage networks**. Press the **+** icon. On the following page, you'll then be prompted to enter the network details for your ContainerChain. For demonstration purposes, the demo EVM ContainerChain is used here, but you can substitute these details for your own ContainerChain. To add your ContainerChain to SubWallet, take the following steps:
 
 1. Paste in the HTTPS RPC URL of your ContainerChain. The demo EVM ContainerChain's RPC URL is `https://fraa-dancebox-3001-rpc.a.dancebox.tanssi.network/`. Other parameters will be auto-populated
-2. Paste in the block explorer URL of your ContainerChain. The demo EVM ContainerChain's block explorer URL is `https://tanssi-evmexplorer.netlify.app/`
+2. Paste in the block explorer URL of your ContainerChain. The demo EVM ContainerChain's block explorer URL is `https://3001-blockscout.a.dancebox.tanssi.network/`
 3. Press **Save**
 
 ![Add your ContainerChain Network Details in SubWallet](/images/builders/interact/ethereum-api/wallets/subwallet/subwallet-6.webp)

--- a/builders/interact/ethereum-api/wallets/talisman.md
+++ b/builders/interact/ethereum-api/wallets/talisman.md
@@ -73,7 +73,7 @@ To configure Talisman for your EVM ContainerChain, open the Talisman extension a
 On the following page, you'll then be prompted to enter the network details for your ContainerChain. For demonstration purposes, the demo EVM ContainerChain is used here, but you can substitute these details for your own ContainerChain. To add your ContainerChain to Talisman, take the following steps: 
 
 1. Paste in the RPC URL of your ContainerChain. The demo EVM ContainerChain's RPC URL is `https://fraa-dancebox-3001-rpc.a.dancebox.tanssi.network/`. Other parameters will be autopopulated
-2. Paste in the block explorer URL of your ContainerChain. The demo EVM ContainerChain's block explorer URL is `https://tanssi-evmexplorer.netlify.app/`
+2. Paste in the block explorer URL of your ContainerChain. The demo EVM ContainerChain's block explorer URL is `https://3001-blockscout.a.dancebox.tanssi.network/`
 3. Check the **This is a testnet** box if applicable
 4. Press **Add Network**
 

--- a/builders/tanssi-network/networks/dancebox/demo-evm-containerchain.md
+++ b/builders/tanssi-network/networks/dancebox/demo-evm-containerchain.md
@@ -78,5 +78,5 @@ The EVM ContainerChain has a [chain ID](https://chainlist.org/chain/5678){target
 For the EVM ContainerChain, you can use any of the following explorers:
 
 - Substrate API - on [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://fraa-dancebox-3001-rpc.a.dancebox.tanssi.network#/explorer){target=\_blank}
-- EVM explorer - on [Blockscout](https://3001-blockscout.a.dancebox.tanssi.network/){target=\_blank}
+- EVM explorer - on [Blockscout](https://3001-blockscout.a.dancebox.tanssi.network/){target=\_blank} or [Expedition](https://tanssi-evmexplorer.netlify.app/){target=\_blank}
 


### PR DESCRIPTION
### Description

This PR updates and clarifies the default block explorer. Blockscout is the default and Expedition has been noted as an alternative option. 

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
