### PR TITLE
Run a Collator using Docker - fix scripts

### DIFF
--- a/.snippets/code/node-operators/block-producers/run-a-block-producer/block-producer-docker/terminal/pulling-docker-image.md
+++ b/.snippets/code/node-operators/block-producers/run-a-block-producer/block-producer-docker/terminal/pulling-docker-image.md
@@ -1,16 +1,16 @@
 <div id="termynal" data-termynal>
-  <span data-ty="input"><span class="file-path"></span>docker pull moondancelabs/parachain-dancebox</span>
+  <span data-ty="input"><span class="file-path"></span>docker pull moondancelabs/tanssi</span>
   <span data-ty>
     <br> 
     <br> Using default tag: latest
-    <br> latest: Pulling from moondancelabs/parachain-dancebox
+    <br> latest: Pulling from moondancelabs/tanssi
     <br> e1caac4eb9d2: Pull complete 
     <br> 1d4409959e6d: Pull complete 
     <br> b8beed19c122: Pull complete 
     <br> c0fab1f18601: Pull complete 
     <br> d9dcf3cddfc5: Pull complete 
     <br> Digest: sha256:0f717d6cf247bbb1b082f5f9e5761b23c44a0be8b704492a57fdbf8c63c0a91c
-    <br> Status: Downloaded newer image for moondancelabs/parachain-dancebox:latest
-    <br> docker.io/moondancelabs/parachain-dancebox:latest
+    <br> Status: Downloaded newer image for moondancelabs/tanssi
+    <br> docker.io/moondancelabs/tanssi:latest
   </span>
 </div>

--- a/.snippets/text/node-operators/block-producers/run-a-block-producer/docker-command.md
+++ b/.snippets/text/node-operators/block-producers/run-a-block-producer/docker-command.md
@@ -1,4 +1,4 @@
---chain=/chain-network/dancebox-raw-specs.json \
+--chain=dancebox \
 --rpc-port=9944 \
 --name=INSERT_YOUR_TANSSI_NODE_NAME \
 --base-path=/data/para \
@@ -11,7 +11,7 @@
 --base-path=/data/container \
 -- \
 --name=INSERT_YOUR_RELAY_NODE_NAME \
---chain=/chain-network/westend-raw-specs.json \
+--chain=westend_moonbase_relay_testnet \
 --rpc-port=9945 \
 --sync=fast \
 --base-path=/data/relay \

--- a/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker.md
+++ b/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker.md
@@ -31,6 +31,19 @@ The command will download and extract the image and show the status upon executi
 
 --8<-- 'code/node-operators/block-producers/run-a-block-producer/block-producer-docker/terminal/pulling-docker-image.md'
 
+### Setup the Data Directory {: #setup-data-directory }
+
+Running a block producer requires syncing with three chains: the relay chain, the Tanssi chain, and the Appchain it has been assigned to.
+
+Run the following command to create the directory where your block producer will store the databases containing blocks and chain states:
+
+```bash
+mkdir /var/lib/dancebox
+```
+
+!!! note
+    The directory is a parameter in the Docker start-up command. If you decide to create the directory elsewhere, update the command accordingly.
+
 ## Start-Up Command {: #start-up-command }
 
 To spin up your node, you must run the Docker image with the `docker run` command. 

--- a/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker.md
+++ b/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker.md
@@ -24,7 +24,7 @@ A Docker image combines the binary corresponding to the latest stable release of
 The following command to pull the Docker image:
 
 ```bash
-docker pull moondancelabs/parachain-dancebox
+docker pull moondancelabs/tanssi
 ```
 
 The command will download and extract the image and show the status upon execution:

--- a/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker.md
+++ b/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker.md
@@ -73,7 +73,9 @@ Name each of the sections with a human-readable name by replacing the `INSERT_YO
 === "Generic"
 
     ```bash
-    docker run --network="host" -v "/var/lib/dancebox:/data" moondancelabs/tanssi \
+    docker run --network="host" -v "/var/lib/dancebox:/data" \
+    -u $(id -u ${USER}):$(id -g ${USER}) \
+    moondancelabs/tanssi \
     --8<-- 'text/node-operators/block-producers/run-a-block-producer/docker-command.md'
     ```
 
@@ -81,6 +83,7 @@ Name each of the sections with a human-readable name by replacing the `INSERT_YO
 
     ```bash
     docker run --network="host" -v "/var/lib/dancebox:/data" \
+    -u $(id -u ${USER}):$(id -g ${USER}) \
     --entrypoint "/tanssi/tanssi-node-skylake" \
     moondancelabs/tanssi \
     --8<-- 'text/node-operators/block-producers/run-a-block-producer/docker-command.md'
@@ -89,6 +92,7 @@ Name each of the sections with a human-readable name by replacing the `INSERT_YO
 
     ```bash
     docker run --network="host" -v "/var/lib/dancebox:/data" \
+    -u $(id -u ${USER}):$(id -g ${USER}) \
     --entrypoint "/tanssi/tanssi-node-znver3" \
     moondancelabs/tanssi \
     --8<-- 'text/node-operators/block-producers/run-a-block-producer/docker-command.md'

--- a/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker.md
+++ b/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker.md
@@ -41,6 +41,18 @@ Run the following command to create the directory where your block producer will
 mkdir /var/lib/dancebox
 ```
 
+Set the folder's ownership to the account that will run the Docker image to ensure writing permission:
+
+```bash
+chown INSERT_DOCKER_USER /var/lib/dancebox
+```
+
+Or run the following command if you want to run the block producer with the current logged-in user:
+
+```bash
+sudo chown -R $(id -u):$(id -g) /var/lib/dancebox
+```
+
 !!! note
     The directory is a parameter in the Docker start-up command. If you decide to create the directory elsewhere, update the command accordingly.
 


### PR DESCRIPTION
### Description

This PR fixes some left behind names for the docker image run scripts in the "running a collator using the docker" article
It also changes how to reference the specifications file to the embedded way coming in the official release tomorrow.

### Checklist

- [ ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
