### PR TITLE
update commands for running a block producer 

### DIFF
--- a/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/docker-command.md
+++ b/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/docker-command.md
@@ -5,6 +5,7 @@
 --blocks-pruning=2000 \
 --collator \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
+--database paritydb
 -- \
 --name=INSERT_YOUR_BLOCK_PRODUCER_NODE_NAME \
 --base-path=/data/container \
@@ -16,4 +17,5 @@
 --base-path=/data/relay \
 --state-pruning=2000 \
 --blocks-pruning=2000 \
---telemetry-url='wss://telemetry.polkadot.io/submit/ 0'
+--telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
+--database paritydb 

--- a/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/docker-command.md
+++ b/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/docker-command.md
@@ -5,7 +5,7 @@
 --blocks-pruning=2000 \
 --collator \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
---database paritydb
+--database paritydb \
 -- \
 --name=INSERT_YOUR_BLOCK_PRODUCER_NODE_NAME \
 --base-path=/data/container \
@@ -18,4 +18,4 @@
 --state-pruning=2000 \
 --blocks-pruning=2000 \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
---database paritydb 
+--database paritydb

--- a/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/docker-command.md
+++ b/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/docker-command.md
@@ -1,19 +1,19 @@
 --chain=dancebox \
---rpc-port=9944 \
 --name=INSERT_YOUR_TANSSI_NODE_NAME \
 --base-path=/data/para \
 --state-pruning=2000 \
 --blocks-pruning=2000 \
 --collator \
+--telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 -- \
---rpc-port=9946 \
 --name=INSERT_YOUR_BLOCK_PRODUCER_NODE_NAME \
 --base-path=/data/container \
+--telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 -- \
 --name=INSERT_YOUR_RELAY_NODE_NAME \
 --chain=westend_moonbase_relay_testnet \
---rpc-port=9945 \
 --sync=fast \
 --base-path=/data/relay \
 --state-pruning=2000 \
 --blocks-pruning=2000 \
+--telemetry-url='wss://telemetry.polkadot.io/submit/ 0'

--- a/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
+++ b/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
@@ -96,12 +96,10 @@ Set the folder's ownership to the account that will run the service to ensure wr
 sudo chown -R tanssi_service /var/lib/tanssi-data
 ```
 
-And finally, move the binary and the chain specs to the folder:
+And finally, move the binary to the folder:
 
 ```bash
-mv ./tanssi-node /var/lib/tanssi-data && \
-mv ./westend-alphanet-raw-specs.json /var/lib/tanssi-data && \
-mv ./dancebox-raw-specs.json /var/lib/tanssi-data
+mv ./tanssi-node /var/lib/tanssi-data
 ```
 
 ### Create the Systemd Service Configuration File {: #create-systemd-configuration }
@@ -131,7 +129,7 @@ SyslogIdentifier=tanssi
 SyslogFacility=local7
 KillSignal=SIGHUP
 ExecStart=/var/lib/tanssi-data/tanssi-node \
---chain=/var/lib/tanssi-data/dancebox-raw-specs.json \
+--chain=dancebox \
 --name=INSERT_YOUR_TANSSI_NODE_NAME \
 --base-path=/var/lib/tanssi-data/para \
 --state-pruning=2000 \
@@ -145,7 +143,7 @@ ExecStart=/var/lib/tanssi-data/tanssi-node \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 -- \
 --name=INSERT_YOUR_RELAY_NODE_NAME \
---chain=/var/lib/tanssi-data/westend-alphanet-raw-specs.json \
+--chain=westend_moonbase_relay_testnet \
 --sync=fast \
 --base-path=/var/lib/tanssi-data/relay \
 --state-pruning=2000 \

--- a/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
+++ b/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
@@ -106,7 +106,7 @@ mv ./dancebox-raw-specs.json /var/lib/tanssi-data
 
 ### Create the Systemd Service Configuration File {: #create-systemd-configuration }
 
-The next step is to create the Systemd configuration file. 
+The next step is to create the Systemd configuration file.
 
 You can create the file by running the following command:
 
@@ -132,24 +132,24 @@ SyslogFacility=local7
 KillSignal=SIGHUP
 ExecStart=/var/lib/tanssi-data/tanssi-node \
 --chain=/var/lib/tanssi-data/dancebox-raw-specs.json \
---rpc-port=9944 \
 --name=INSERT_YOUR_TANSSI_NODE_NAME \
 --base-path=/var/lib/tanssi-data/para \
 --state-pruning=2000 \
 --blocks-pruning=2000 \
 --collator \
+--telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 -- \
---rpc-port=9946 \
 --name=tanssi-appchain \
 --base-path=/var/lib/tanssi-data/container \
+--telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 -- \
 --name=INSERT_YOUR_RELAY_NODE_NAME \
 --chain=/var/lib/tanssi-data/westend-alphanet-raw-specs.json \
---rpc-port=9945 \
 --sync=fast \
 --base-path=/var/lib/tanssi-data/relay \
 --state-pruning=2000 \
 --blocks-pruning=2000 \
+--telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 
 [Install]
 WantedBy=multi-user.target

--- a/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
+++ b/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
@@ -138,6 +138,7 @@ ExecStart=/var/lib/tanssi-data/tanssi-node \
 --blocks-pruning=2000 \
 --collator \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
+--database paritydb \
 -- \
 --name=tanssi-appchain \
 --base-path=/var/lib/tanssi-data/container \
@@ -150,6 +151,7 @@ ExecStart=/var/lib/tanssi-data/tanssi-node \
 --state-pruning=2000 \
 --blocks-pruning=2000 \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
+--database paritydb \
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### Description

Art requested that we add `--telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \` and Oskar suggested leaving out the `rpc-port` commands as they are pointing to the default ports anyways

### Checklist

- [x] I have added a label to this PR 🏷️

