### PR TITLE
fix the systemd block producer name command

### DIFF
--- a/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
+++ b/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
@@ -139,7 +139,7 @@ ExecStart=/var/lib/tanssi-data/tanssi-node \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --database paritydb \
 -- \
---name=tanssi-appchain \
+--name=INSERT_YOUR_BLOCK_PRODUCER_NODE_NAME \
 --base-path=/var/lib/tanssi-data/container \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 -- \


### PR DESCRIPTION
### Description

Fix the block producer section name for the run a block producer node command

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
