### PR TITLE
Update block-producer-systemd.md

### DIFF
--- a/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
+++ b/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
@@ -111,12 +111,12 @@ ExecStart=/var/lib/tanssi-data/tanssi-node \
 --state-pruning=2000 \
 --blocks-pruning=2000 \
 --collator \
---telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --database paritydb \
+--telemetry-url='wss://telemetry.polkadot.io/submit/ 0' 
 -- \
 --name=INSERT_YOUR_BLOCK_PRODUCER_NODE_NAME \
 --base-path=/var/lib/tanssi-data/container \
---telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
+--telemetry-url='wss://telemetry.polkadot.io/submit/ 0' 
 -- \
 --chain=westend_moonbase_relay_testnet \
 --name=INSERT_YOUR_RELAY_NODE_NAME \
@@ -124,8 +124,8 @@ ExecStart=/var/lib/tanssi-data/tanssi-node \
 --base-path=/var/lib/tanssi-data/relay \
 --state-pruning=2000 \
 --blocks-pruning=2000 \
---telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --database paritydb \
+--telemetry-url='wss://telemetry.polkadot.io/submit/ 0' 
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The service file contains unnecessary backslashes at the ends of telemetry lines. (telemetry-url='wss://telemetry.polkadot.io/submit/0' \). Because of this, the binary file is launched with only part of the flags, as a result of which the node does not synchronize.

### Description

Please explain the changes this PR addresses here.

### Checklist

- [ ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
