### PR TITLE
[Builders-Templates] Moved the included modules section to overview

### DIFF
--- a/builders/build/templates/evm.md
+++ b/builders/build/templates/evm.md
@@ -15,7 +15,7 @@ Tanssi's EVM appchain template is specifically designed for teams developing the
 
 ## EVM Appchain Template {: #evm-appchain-template }
 
-Since the template already contains the necessary configuration for seamless integration into the Polkadot ecosystem and for Tanssi protocol compatibility, if the use case is entirely developed on top of the EVM, then this template requires no additional changes in the runtime.
+Since the template already contains the necessary configuration for seamless integration into the Polkadot ecosystem and Tanssi protocol compatibility, if the use case is entirely developed on top of the EVM, then this template requires no additional changes in the runtime.
 
 This means that this template is ready to be built as-is and deployed through Tanssi, unlocking many features, such as:
 
@@ -30,11 +30,11 @@ This means that this template is ready to be built as-is and deployed through Ta
 
 ## Included Modules {: #included-modules }
 
-The Tanssi EVM appchain template is built on top of the [Substrate appchain template](/builders/build/templates/substrate/){target=\_blank}. Consequently, it includes the same [baseline modules](/builders/build/templates/substrate/#included-modules).
+Besides the modules and configurations that make the Tanssi EVM appchain template compatible with the Tanssi protocol, It also includes [many modules](/builders/build/templates/overview/#included-modules){target=\_blank} to provide basic functionalities.
 
-In addition, the specific modules included for full Ethereum-compatibility are the following:
+To reach full Ethereum compatibility, these specific modules are also included:
 
 - **[pallet_evm](https://docs.rs/pallet-evm/latest/pallet_evm/){target=\_blank}** - the EVM pallet allows for unmodified EVM bytecode to be executed in a Substrate-based blockchain. It uses the Rust-based [SputnikVM](https://github.com/rust-ethereum/evm){target=\_blank} as the underlying EVM engine
 - **[pallet_ethereum](https://docs.rs/pallet-ethereum/latest/pallet_ethereum/){target=\_blank}** - the Ethereum pallet works together with the EVM pallet to provide full emulation for Ethereum block processing. Among many other tasks, it is responsible for creating emulated Ethereum blocks for Ethereum-specific components such as EVM logs
 
-Both of the included modules are part of [Frontier](https://github.com/paritytech/frontier){target=\_blank}, which is the backbone of Ethereum-compatible Substrate-based chains.
+Both modules are part of [Frontier](https://github.com/paritytech/frontier){target=\_blank}, which is the backbone of Ethereum-compatible Substrate-based chains.

--- a/builders/build/templates/evm.md
+++ b/builders/build/templates/evm.md
@@ -30,7 +30,7 @@ This means that this template is ready to be built as-is and deployed through Ta
 
 ## Included Modules {: #included-modules }
 
-Besides the modules and configurations that make the Tanssi EVM appchain template compatible with the Tanssi protocol, It also includes [many modules](/builders/build/templates/overview/#included-modules){target=\_blank} to provide basic functionalities.
+Besides the modules and configurations that make the Tanssi EVM appchain template compatible with the Tanssi protocol, it also includes [many modules](/builders/build/templates/overview/#included-modules){target=\_blank} to provide basic functionalities.
 
 To reach full Ethereum compatibility, these specific modules are also included:
 

--- a/builders/build/templates/overview.md
+++ b/builders/build/templates/overview.md
@@ -43,6 +43,19 @@ If you don't include these modules in the Tanssi appchain's runtime, there won't
 
 More information about Tanssi's block production as a service and the interaction between Tanssi, the relay chain, and your Tanssi appchain can be found in the [Technical Features](/learn/tanssi/technical-features/#block-production-as-a-service){target=\_blank} article.
 
+## Included Modules {: #included-modules }
+
+Besides the necessary modules to support the operation of the Tanssi appchain as part of the broader Polkadot ecosystem and the modules that enable the Tanssi protocol and its block production mechanism, many other modules provide functional behavior that the users can interact with. 
+
+These are some of the functional modules exposing a behavior to the users that are included in the templates and ready to use:
+
+- **[pallet_balances](https://paritytech.github.io/substrate/master/pallet_balances/index.html){target=\_blank}** - the Balances pallet provides functions for handling accounts and balances for the Tanssi appchain native currency
+- **[pallet_utility](https://paritytech.github.io/polkadot-sdk/master/pallet_utility/index.html){target=\_blank}** - the Utility pallet provides functions to execute multiple calls in a single dispatch. Besides batching transactions, this module also allows the execution of a call from an alternative signed origin
+- **[pallet_proxy](https://paritytech.github.io/polkadot-sdk/master/pallet_proxy/index.html){target=\_blank}** - the Proxy pallet provides functions to delegate to other accounts (proxies) the permission to dispatch calls from a proxied origin
+- **[pallet_maintenance_mode](https://github.com/moondance-labs/moonkit/blob/tanssi-polkadot-v1.3.0/pallets/maintenance-mode/src/lib.rs){target=\_blank}** - the Maintenance Mode pallet allows the Tanssi appchain to be set to a mode where it doesn't execute balance/asset transfers or other transactions, such as XCM calls. This could be useful when upgrading the runtime in an emergency, when executing large storage migrations, or when a security vulnerability is discovered
+- **[pallet_tx_pause](https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/tx-pause/src/lib.rs){target=\_blank}** - the Tx Pause pallet allows a valid origin (typically Root) to pause (and unpause) an entire module or a single transaction. A paused transaction (or all the transactions included in a paused pallet) will fail when called until it is unpaused. This module provides a higher degree of granularity compared to maintenance mode, making it particularly useful when a faulty or vulnerable transaction is identified in the runtime
+- **[pallet_multisig](https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/multisig/src/lib.rs){target=\_blank}** - the Multisig pallet enables transaction dispatches that require -typically- more than one signature. A multisig transaction defines a set of authorized accounts and a threshold for its approval, requiring consensus among multiple parties
+
 ## Start Building {: #getting-started }
 
 To start building on top of the provided templates, be it the [Baseline Tanssi appchain template](/builders/build/templates/substrate){target=\_blank} or the [Baseline EVM (Ethereum Virtual Machine) template](/builders/build/templates/evm){target=\_blank}, the recommended approach is to fork the [Tanssi repository](https://github.com/moondance-labs/tanssi){target=\_blank} and start adding [built-in modules](/builders/build/customize/adding-built-in-module/){target=\_blank} or [custom-made modules](/builders/build/customize/adding-custom-made-module/){target=\_blank} on top of the [latest release](https://github.com/moondance-labs/tanssi/releases/latest){target=\_blank} tag.

--- a/builders/build/templates/substrate.md
+++ b/builders/build/templates/substrate.md
@@ -29,20 +29,8 @@ Here are some of the features that come with this template:
 
 By leveraging these features in the template, you can kickstart your Tanssi appchain development and customize it to meet your specific requirements and innovations.
 
-## Included Modules {: #included-modules }
-
-Some of the included modules are necessary for supporting the operation of the Tanssi appchain as part of the broader Polkadot ecosystem, some other modules are included to enable the Tanssi protocol and its block production mechanism, and some other modules provide functional behavior that the users can interact with. 
-
-These are some of the functional modules exposing a behavior to the users that are included and ready to use:
-
-- **[pallet_balances](https://paritytech.github.io/substrate/master/pallet_balances/index.html){target=\_blank}** - the Balances pallet provides functions for handling accounts and balances for the Tanssi appchain native currency
-- **[pallet_utility](https://paritytech.github.io/polkadot-sdk/master/pallet_utility/index.html){target=\_blank}** - the Utility pallet provides functions to execute multiple calls in a single dispatch. Besides batching transactions, this module also allows the execution of a call from an alternative signed origin
-- **[pallet_proxy](https://paritytech.github.io/polkadot-sdk/master/pallet_proxy/index.html){target=\_blank}** - the Proxy pallet provides functions to delegate to other accounts (proxies) the permission to dispatch calls from a proxied origin
-- **[pallet_maintenance_mode](https://github.com/moondance-labs/moonkit/blob/tanssi-polkadot-v1.3.0/pallets/maintenance-mode/src/lib.rs){target=\_blank}** - the Maintenance Mode pallet allows the Tanssi appchain to be set to a mode where it doesn't execute balance/asset transfers or other transactions, such as XCM calls. This could be useful when upgrading the runtime in an emergency, when executing large storage migrations, or when a security vulnerability is discovered
-- **[pallet_tx_pause](https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/tx-pause/src/lib.rs){target=\_blank}** - the Tx Pause pallet allows a valid origin (typically Root) to pause (and unpause) an entire module or a single transaction. A paused transaction (or all the transactions included in a paused pallet) will fail when called until it is unpaused. This module provides a higher degree of granularity compared to maintenance mode, making it particularly useful when a faulty or vulnerable transaction is identified in the runtime
-
 ## Adding Extra Dependencies {: #adding-extra-dependencies }
 
-The Substrate appchain template is meant to be built on top of, as the included modules are just for basic functionality and to ensure it is compatible with Tanssi.
+The Substrate appchain template includes all the required modules and configurations that make it compatible with the Tanssi protocol, and also [many other modules](/builders/build/templates/overview/#included-modules){target=\_blank} that provide basic functionalities.
 
-To learn how to add new functionalities to your runtime, check the [customize runtime](/builders/build/customize/){target=\_blank} section.
+This template is meant to be built on top of it, as most use cases require expanded capabilities, adding existing or custom modules. To learn how to add new functionalities to your runtime, check the [customize runtime](/builders/build/customize/){target=\_blank} section.


### PR DESCRIPTION
### Description

This PR moves the list of included modules in the templates from the substrate template to the overview article, as those modules as common to both available templates.
It also adds the multisig module, which was included in the RT 500

### Checklist

- [x] I have added a label to this PR 🏷️
- [x] I have run my changes through Grammarly
- [x] If this page requires a disclaimer, I have added one
- [x] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
