### PR TITLE
Update Block Explorer Links

### DIFF
--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/balances.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/balances.ts
@@ -24,7 +24,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
+      url: 'https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/deploy.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/deploy.ts
@@ -31,7 +31,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
+      url: 'https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/get.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/get.ts
@@ -25,7 +25,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
+      url: 'https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/increment.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/increment.ts
@@ -31,7 +31,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
+      url: 'https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/read-chain-data.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/read-chain-data.ts
@@ -24,7 +24,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
+      url: 'https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/reset.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/reset.ts
@@ -31,7 +31,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
+      url: 'https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/transaction.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/transaction.ts
@@ -31,7 +31,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
+      url: 'https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/.snippets/code/builders/interact/ethereum-api/libraries/viem/write-chain-data.ts
+++ b/.snippets/code/builders/interact/ethereum-api/libraries/viem/write-chain-data.ts
@@ -25,7 +25,7 @@ export const demoEVM = defineChain({
   blockExplorers: {
     default: {
       name: 'Explorer',
-      url: 'https://3001-blockscout.a.dancebox.tanssi.network/',
+      url: 'https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/',
     },
   },
 });

--- a/builders/interact/ethereum-api/dev-env/foundry.md
+++ b/builders/interact/ethereum-api/dev-env/foundry.md
@@ -179,7 +179,7 @@ Your forked instance will have 10 development accounts that are pre-funded with 
 
 ![Forking terminal screen](/images/builders/interact/ethereum-api/dev-environments/foundry/foundry-5.webp)
 
-To verify you have forked the network, you can query the latest block number and compare it to the current block number of the [demo EVM appchain](https://3001-blockscout.a.dancebox.tanssi.network/){target=\_blank}.
+To verify you have forked the network, you can query the latest block number and compare it to the current block number of the [demo EVM appchain](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/){target=\_blank}.
 
 ```bash
 curl --data '{"method":"eth_blockNumber","params":[],"id":1,"jsonrpc":"2.0"}' -H "Content-Type: application/json" -X POST localhost:8545 

--- a/builders/interact/ethereum-api/wallets/metamask.md
+++ b/builders/interact/ethereum-api/wallets/metamask.md
@@ -76,7 +76,7 @@ Here, you can configure MetaMask for the following networks:
 |          RPC URL          | `https://fraa-dancebox-3001-rpc.a.dancebox.tanssi.network` |
 |         Chain ID          |                           `5678`                           |
 |     Symbol (Optional)     |                          `TANGO`                           |
-| Block Explorer (Optional) |    `https://3001-blockscout.a.dancebox.tanssi.network/`    |
+| Block Explorer (Optional) |    `https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/`    |
 
 To do so, fill in the following information:
 

--- a/builders/interact/ethereum-api/wallets/subwallet.md
+++ b/builders/interact/ethereum-api/wallets/subwallet.md
@@ -50,7 +50,7 @@ On the following screen, you'll be able to provide the relevant seed phrase, pri
 To configure SubWallet for your Tanssi EVM appchain, press the **More Options** icon in the upper left corner. Then click **Manage networks**. Press the **+** icon. On the following page, you'll then be prompted to enter the network details for your Tanssi appchain. For demonstration purposes, the demo EVM appchain is used here, but you can substitute these details for your own Tanssi appchain. To add your Tanssi appchain to SubWallet, take the following steps:
 
 1. Paste in the HTTPS RPC URL of your Tanssi appchain. The demo EVM appchain's RPC URL is `https://fraa-dancebox-3001-rpc.a.dancebox.tanssi.network/`. Other parameters will be auto-populated
-2. Paste in the block explorer URL of your Tanssi appchain. The demo EVM appchain's block explorer URL is `https://3001-blockscout.a.dancebox.tanssi.network/`
+2. Paste in the block explorer URL of your Tanssi appchain. The demo EVM appchain's block explorer URL is `https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/`
 3. Press **Save**
 
 ![Add your Tanssi Appchain Network Details in SubWallet](/images/builders/interact/ethereum-api/wallets/subwallet/subwallet-6.webp)

--- a/builders/interact/ethereum-api/wallets/talisman.md
+++ b/builders/interact/ethereum-api/wallets/talisman.md
@@ -73,7 +73,7 @@ To configure Talisman for your Tanssi EVM appchain, open the Talisman extension 
 On the following page, you'll then be prompted to enter the network details for your Tanssi appchain. For demonstration purposes, the demo EVM appchain is used here, but you can substitute these details for your own Tanssi appchain. To add your Tanssi appchain to Talisman, take the following steps: 
 
 1. Paste in the RPC URL of your Tanssi appchain. The demo EVM appchain's RPC URL is `https://fraa-dancebox-3001-rpc.a.dancebox.tanssi.network/`. Other parameters will be autopopulated
-2. Paste in the block explorer URL of your Tanssi appchain. The demo EVM appchain's block explorer URL is `https://3001-blockscout.a.dancebox.tanssi.network/`
+2. Paste in the block explorer URL of your Tanssi appchain. The demo EVM appchain's block explorer URL is `https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/`
 3. Check the **This is a testnet** box if applicable
 4. Press **Add Network**
 

--- a/builders/tanssi-network/networks/dancebox/demo-evm-containerchain.md
+++ b/builders/tanssi-network/networks/dancebox/demo-evm-containerchain.md
@@ -42,7 +42,7 @@ Then, take the following steps:
 !!! note
     TANGO tokens have no value. Please don't spam the faucet with unnecessary requests. 
 
-Your tokens will be disbursed shortly, and you can verify your TANGO token balance by looking up your address on the [explorer](https://3001-blockscout.a.dancebox.tanssi.network/){target=\_blank}.
+Your tokens will be disbursed shortly, and you can verify your TANGO token balance by looking up your address on the [explorer](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/){target=\_blank}.
 
 ## Quick Start {: #quick-start }
 
@@ -97,5 +97,5 @@ The demo EVM appchain has a [chain ID](https://chainlist.org/chain/5678){target=
 For the demo EVM appchain, you can use any of the following explorers:
 
 - Substrate API - on [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://fraa-dancebox-3001-rpc.a.dancebox.tanssi.network#/explorer){target=\_blank}
-- EVM explorer - on [Blockscout](https://3001-blockscout.a.dancebox.tanssi.network/){target=\_blank} or [Expedition](https://tanssi-evmexplorer.netlify.app/){target=\_blank}
+- EVM explorer - on [Blockscout](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/){target=\_blank} or [Expedition](https://tanssi-evmexplorer.netlify.app/){target=\_blank}
 

--- a/builders/tooling/oracles/acurast.md
+++ b/builders/tooling/oracles/acurast.md
@@ -35,7 +35,7 @@ As seen above in the interface, there are five functions for fetching data: `dec
 
 ## Interacting with Price Feeds on the Tanssi Demo EVM Appchain {: #interacting-with-price-feeds-demo-evm-appchain }
 
-This tutorial will showcase interacting with a sample BTC/USDT price feed contract on the demo EVM appchain, but you can interact any of the price feeds listed in [Supported Assets](#supported-assets). The BTC/USDT price feed is [deployed on the demo EVM appchain](https://3001-blockscout.a.dancebox.tanssi.network/address/0x02093b190D9462d964C11587f7DedD92718D7B56){target=\_blank}, so you can interact with it by accessing the aggregator contract at the below contract address:
+This tutorial will showcase interacting with a sample BTC/USDT price feed contract on the demo EVM appchain, but you can interact any of the price feeds listed in [Supported Assets](#supported-assets). The BTC/USDT price feed is [deployed on the demo EVM appchain](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0x02093b190D9462d964C11587f7DedD92718D7B56){target=\_blank}, so you can interact with it by accessing the aggregator contract at the below contract address:
 
 ```text
 {{ networks.dancebox.oracles.acurast.btc_usd }}
@@ -86,13 +86,13 @@ The Acurast team has deployed the below price feeds on the Tanssi demo EVM appch
 
 | Asset & Base Pair |                                                                          Aggregator Contract                                                                           |
 |:-----------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-|    AAVE to USDT    | [{{ networks.dancebox.oracles.acurast.aave_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0x6239Ff749De3a21DC219bcFeF9d27B0dfE171F42){target=\_blank} |
-|    BTC to USDT     | [{{ networks.dancebox.oracles.acurast.btc_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0x02093b190D9462d964C11587f7DedD92718D7B56){target=\_blank}  |
-|    CRV to USDT     | [{{ networks.dancebox.oracles.acurast.crv_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0x01F143dfd745861902dA396ad7dfca962e5C83cA){target=\_blank}  |
-|    DAI to USDT     | [{{ networks.dancebox.oracles.acurast.dai_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0x73aF6b14b73059686a9B93Cd28b2dEABF76AeC92){target=\_blank}  |
-|    ETH to USDT     | [{{ networks.dancebox.oracles.acurast.eth_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0x007c3F3cc99302c19792F73b7434E3eCbbC3db25){target=\_blank}  |
-|    USDC to USDT    | [{{ networks.dancebox.oracles.acurast.usdc_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0xe4a46ef4cFbf87D026C3eB293b7672998d932F62){target=\_blank} |
-|    USDT to USD    | [{{ networks.dancebox.oracles.acurast.usdt_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0xf9c885E3A5846CEA887a0D69655BC08e52afe569){target=\_blank} |
+|    AAVE to USDT    | [{{ networks.dancebox.oracles.acurast.aave_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0x6239Ff749De3a21DC219bcFeF9d27B0dfE171F42){target=\_blank} |
+|    BTC to USDT     | [{{ networks.dancebox.oracles.acurast.btc_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0x02093b190D9462d964C11587f7DedD92718D7B56){target=\_blank}  |
+|    CRV to USDT     | [{{ networks.dancebox.oracles.acurast.crv_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0x01F143dfd745861902dA396ad7dfca962e5C83cA){target=\_blank}  |
+|    DAI to USDT     | [{{ networks.dancebox.oracles.acurast.dai_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0x73aF6b14b73059686a9B93Cd28b2dEABF76AeC92){target=\_blank}  |
+|    ETH to USDT     | [{{ networks.dancebox.oracles.acurast.eth_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0x007c3F3cc99302c19792F73b7434E3eCbbC3db25){target=\_blank}  |
+|    USDC to USDT    | [{{ networks.dancebox.oracles.acurast.usdc_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0xe4a46ef4cFbf87D026C3eB293b7672998d932F62){target=\_blank} |
+|    USDT to USD    | [{{ networks.dancebox.oracles.acurast.usdt_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0xf9c885E3A5846CEA887a0D69655BC08e52afe569){target=\_blank} |
 
 ## Designing and Launching Your Own Price Feed {: #designing-and-launching-your-own-price-feed }
 

--- a/builders/tooling/oracles/phala.md
+++ b/builders/tooling/oracles/phala.md
@@ -40,13 +40,13 @@ Phala sources its price feed data by mirroring Chainlink's price feeds from Ethe
 === "Tanssi Demo EVM Appchain"
     | Asset & Base Pair |                                                                          Aggregator Contract                                                                           |
     |:-----------------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-    |    AAVE to USD    | [{{ networks.dancebox.oracles.phala.aave_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0x2E1640853bB2dD9f47831582665477865F9240DB){target=\_blank} |
-    |    BTC to USD     | [{{ networks.dancebox.oracles.phala.btc_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0x89BC5048d634859aef743fF2152363c0e83a6a49){target=\_blank}  |
-    |    CRV to USD     | [{{ networks.dancebox.oracles.phala.crv_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0xf38b25b79A72393Fca2Af88cf948D98c64726273){target=\_blank}  |
-    |    DAI to USD     | [{{ networks.dancebox.oracles.phala.dai_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0x1f56d8c7D72CE2210Ef340E00119CDac2b05449B){target=\_blank}  |
-    |    ETH to USD     | [{{ networks.dancebox.oracles.phala.eth_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0x739d71fC66397a28B3A3b7d40eeB865CA05f0185){target=\_blank}  |
-    |    USDC to USD    | [{{ networks.dancebox.oracles.phala.usdc_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0x4b8331Ce5Ae6cd33bE669c10Ded9AeBA774Bf252){target=\_blank} |
-    |    USDT to USD    | [{{ networks.dancebox.oracles.phala.usdt_usd }}](https://3001-blockscout.a.dancebox.tanssi.network/address/0x5018c16707500D2C89a0446C08f347A024f55AE3){target=\_blank} |
+    |    AAVE to USD    | [{{ networks.dancebox.oracles.phala.aave_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0x2E1640853bB2dD9f47831582665477865F9240DB){target=\_blank} |
+    |    BTC to USD     | [{{ networks.dancebox.oracles.phala.btc_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0x89BC5048d634859aef743fF2152363c0e83a6a49){target=\_blank}  |
+    |    CRV to USD     | [{{ networks.dancebox.oracles.phala.crv_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0xf38b25b79A72393Fca2Af88cf948D98c64726273){target=\_blank}  |
+    |    DAI to USD     | [{{ networks.dancebox.oracles.phala.dai_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0x1f56d8c7D72CE2210Ef340E00119CDac2b05449B){target=\_blank}  |
+    |    ETH to USD     | [{{ networks.dancebox.oracles.phala.eth_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0x739d71fC66397a28B3A3b7d40eeB865CA05f0185){target=\_blank}  |
+    |    USDC to USD    | [{{ networks.dancebox.oracles.phala.usdc_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0x4b8331Ce5Ae6cd33bE669c10Ded9AeBA774Bf252){target=\_blank} |
+    |    USDT to USD    | [{{ networks.dancebox.oracles.phala.usdt_usd }}](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/address/0x5018c16707500D2C89a0446C08f347A024f55AE3){target=\_blank} |
 
 === "Ethereum MainNet"
     | Asset & Base Pair |                                                      Aggregator Contract                                                      |


### PR DESCRIPTION
### Description

Updates all block explorer links to reference to the new instance of blockscout for the Demo EVM Container Chain. For reference the old link is: https://3001-blockscout.a.dancebox.tanssi.network/ and the new link is https://fra-dancebox-3001-bs.a.dancebox.tanssi.network/

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
