### PR TITLE
bump client to v0.6.1

### DIFF
--- a/.snippets/code/node-operators/block-producers/operational-tasks/upgrade-your-node/upgrade-docker/terminal/docker-stop.md
+++ b/.snippets/code/node-operators/block-producers/operational-tasks/upgrade-your-node/upgrade-docker/terminal/docker-stop.md
@@ -3,7 +3,7 @@
   <span data-ty>
     <br> 
     <br> CONTAINER ID    IMAGE    COMMAND    CREATED    STATUS  PORTS    NAMES
-    <br> aa751703d6aa moondancelabs/tanssi:v0.5 "/tanssi/tanssi-node…" 56 seconds ago  Up 56 seconds             focused_chaum
+    <br> aa751703d6aa moondancelabs/tanssi:v0.6.1 "/tanssi/tanssi-node…" 56 seconds ago  Up 56 seconds             focused_chaum
     <br> 
     <span data-ty="input"><span class="file-path"></span>docker stop aa751703d6aa</span>
     <br> aa751703d6aa

--- a/node-operators/block-producers/operational-tasks/upgrade-your-node/upgrade-docker.md
+++ b/node-operators/block-producers/operational-tasks/upgrade-your-node/upgrade-docker.md
@@ -63,7 +63,7 @@ To restart the node, you can use the command you used when launching your block 
 
 ### Specifying a Version Tag {: #specifying-a-version-tag }
 
-The Docker commands above will automatically fetch the latest release version tag, but if you wanted to specify a [particular version tag](https://hub.docker.com/r/moondancelabs/tanssi/tags){target=\_blank}, you can do so by appending the version tag to the image name. For example, if you wanted to fetch version `v0.5`, rather than specifying the image name as `moondancelabs/tanssi`, you would indicate `moondancelabs/tanssi:v0.5` as the image name.
+The Docker commands above will automatically fetch the latest release version tag, but if you wanted to specify a [particular version tag](https://hub.docker.com/r/moondancelabs/tanssi/tags){target=\_blank}, you can do so by appending the version tag to the image name. For example, if you wanted to fetch version `{{ networks.dancebox.client_version }}`, rather than specifying the image name as `moondancelabs/tanssi`, you would indicate `moondancelabs/tanssi:{{ networks.dancebox.client_version }}` as the image name.
 
 The complete commands with specific version tags are thus as follows:
 
@@ -72,7 +72,7 @@ The complete commands with specific version tags are thus as follows:
     ```bash
     docker run --network="host" -v "/var/lib/dancebox:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
-    moondancelabs/tanssi:v0.5 \
+    moondancelabs/tanssi:{{ networks.dancebox.client_version }} \
     --8<-- 'code/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker/docker-command.md'
     ```
 
@@ -82,7 +82,7 @@ The complete commands with specific version tags are thus as follows:
     docker run --network="host" -v "/var/lib/dancebox:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     --entrypoint "/tanssi/tanssi-node-skylake" \
-    moondancelabs/tanssi:v0.5 \
+    moondancelabs/tanssi:{{ networks.dancebox.client_version }} \
     --8<-- 'code/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker/docker-command.md'
     ```
 
@@ -92,7 +92,7 @@ The complete commands with specific version tags are thus as follows:
     docker run --network="host" -v "/var/lib/dancebox:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     --entrypoint "/tanssi/tanssi-node-znver3" \
-    moondancelabs/tanssi:v0.5 \
+    moondancelabs/tanssi:{{ networks.dancebox.client_version }} \
     --8<-- 'code/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker/docker-command.md'
     ```
 And that's it! You've successfully upgraded your Tanssi node.

--- a/variables.yml
+++ b/variables.yml
@@ -1,6 +1,6 @@
 networks:
   dancebox:
-    client_version: v0.5.0
+    client_version: v0.6.1
     substrate_api_sidecar:
       stable_version: 17.1.2
     chain_id: 5678


### PR DESCRIPTION
### Description

This PR bumps the Tanssi client version to v0.6.1 and makes sure we're using variables for the client version

### Checklist

- [x] I have added a label to this PR 🏷️

