### PR TITLE
Adds open ports requirement

### DIFF
--- a/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/hardware-requirements.md
+++ b/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/hardware-requirements.md
@@ -13,3 +13,13 @@ The following are some hardware recommendations that have performed well:
 !!! warning 
     You are responsible not only for your own stake but also the stake of your delegators. Monitoring your block producer performance and keeping it up to date and secured correctly is critical to maximizing rewards and building up your reputation.
 
+### Running Ports {: #running-ports }
+
+As mentioned in the [Introduction](#introduction), block producer nodes will be assigned to produce blocks for any active appchain in the Tanssi ecosystem or the Tanssi protocol itself. To accomplish this, the node must be able to sync and participate in three different peer-to-peer (P2P) networks. This requires the following three ports to be open to receive communications from **any** origin:
+
+|      Description      |    Port     |
+|:---------------------:|:-----------:|
+| **Assigned Appchain** | 30333 (TCP) |
+|  **Tanssi Protocol**  | 30335 (TCP) |
+|    **Relay Chain**    | 30334 (TCP) |
+

--- a/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/hardware-requirements.md
+++ b/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/hardware-requirements.md
@@ -15,11 +15,11 @@ The following are some hardware recommendations that have performed well:
 
 ### Running Ports {: #running-ports }
 
-As mentioned in the [Introduction](#introduction), block producer nodes will be assigned to produce blocks for any active appchain in the Tanssi ecosystem or the Tanssi protocol itself. To accomplish this, the node must be able to sync and participate in three different peer-to-peer (P2P) networks. This requires the following three ports to be open to receive communications from **any** origin:
+As mentioned in the [Introduction](#introduction), block producer nodes will be assigned to produce blocks for any active appchain in the Tanssi ecosystem or the Tanssi protocol itself. To accomplish a successful block production, the node must be able to sync and participate in three different peer-to-peer (P2P) networks. This requires the following three ports to be open to incoming communications from **any** origin:
 
-|      Description      |    Port     |
+|        Network        |    Port     |
 |:---------------------:|:-----------:|
-| **Assigned Appchain** | 30333 (TCP) |
-|  **Tanssi Protocol**  | 30335 (TCP) |
+|   **Tanssi Chain**    | 30333 (TCP) |
 |    **Relay Chain**    | 30334 (TCP) |
+| **Assigned Appchain** | 30335 (TCP) |
 


### PR DESCRIPTION
### Description

This PR adds the open ports reuirement for block producers
Note that the ports are in a code snippet, and variables are not rendered properly

### Checklist

- [x] I have added a label to this PR 🏷️
- [x] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
