### PR TITLE
Updates binary template names

### DIFF
--- a/builders/build/customize/adding-built-in-module.md
+++ b/builders/build/customize/adding-built-in-module.md
@@ -27,7 +27,7 @@ You can read more about how to install the required components in the [prerequis
 As this article is based on the EVM template, make sure that it compiles correctly before continuing by executing the following command:
 
 ```bash
-cargo build -p container-chain-template-frontier-node --release
+cargo build -p container-chain-frontier-node --release
 ```
 
 ## Adding a Built-in Module to the Runtime {: #adding-a-built-in-module-to-runtime }

--- a/builders/build/customize/adding-external-module.md
+++ b/builders/build/customize/adding-external-module.md
@@ -133,7 +133,7 @@ After completing the preceding steps, the module is declared a dependency in the
 Compile the template using the following command:
 
 ```bash
-cargo build -p container-chain-template-simple-node --release
+cargo build -p container-chain-simple-node --release
 ```
 
 The terminal output will display an error, similar to the following, caused by different modules referencing different versions of the same dependency:

--- a/builders/build/customize/customizing-chain-specs.md
+++ b/builders/build/customize/customizing-chain-specs.md
@@ -70,7 +70,7 @@ To build and generate the chain specifications, take the following steps:
 3. Build the Tanssi EVM-compatible appchain template
 
     ```bash
-    cargo build -p container-chain-template-frontier-node --release
+    cargo build -p container-chain-frontier-node --release
     ```
 
     This step is quite verbose and might take a while to complete. The following screenshot shows the terminal after successfully finishing the building process (note that the completion time is above 35 minutes):
@@ -80,7 +80,7 @@ To build and generate the chain specifications, take the following steps:
 4. Generate the chain specification
 
     ```bash
-    ./target/release/container-chain-template-frontier-node \
+    ./target/release/container-chain-frontier-node \
         build-spec > chain_spec.json
     ```
 
@@ -206,7 +206,7 @@ One final step before deploying the Tanssi appchain is converting the JSON speci
 After going through the [steps to generate the JSON chain Specification File](#generating-json-chain-specs) and editing its values, the following command will convert the chain specs file into the required raw format:
 
 ```bash
-./target/release/container-chain-template-frontier-node \
+./target/release/container-chain-frontier-node \
     build-spec --chain=chain_spec.json --raw > raw_chain_spec.json
 ```
 

--- a/builders/build/customize/prerequisites.md
+++ b/builders/build/customize/prerequisites.md
@@ -111,13 +111,13 @@ cd tanssi
 === "Baseline EVM"
 
     ```bash
-    cargo build -p container-chain-template-frontier-node --release
+    cargo build -p container-chain-frontier-node --release
     ```
 
 === "Baseline Substrate"
 
     ```bash
-    cargo build -p container-chain-template-simple-node --release
+    cargo build -p container-chain-simple-node --release
     ```
 
 Having a healthy development environment will be necessary to build a customized runtime and to finally generate the chain specification file that will be used to deploy your Tanssi appchain.

--- a/node-operators/appchain-node/rpc-docker.md
+++ b/node-operators/appchain-node/rpc-docker.md
@@ -65,7 +65,7 @@ To spin up your node, you must run the Docker image with the `docker run` comman
 
         ```bash
         docker run -ti moondancelabs/dancebox-container-chain-evm-templates \
-        /chain-network/container-chain-template-frontier-node \
+        /chain-network/container-chain-frontier-node \
         --8<-- 'code/node-operators/appchain-node/rpc-docker/docker-command.md'
         ```
 
@@ -73,7 +73,7 @@ To spin up your node, you must run the Docker image with the `docker run` comman
 
         ```bash
         docker run -ti moondancelabs/dancebox-container-chain-evm-templates \
-        /chain-network/container-chain-template-frontier-node-skylake \
+        /chain-network/container-chain-frontier-node-skylake \
         --8<-- 'code/node-operators/appchain-node/rpc-docker/docker-command.md'
         ```
 
@@ -81,7 +81,7 @@ To spin up your node, you must run the Docker image with the `docker run` comman
 
         ```bash
         docker run -ti moondancelabs/dancebox-container-chain-evm-templates \
-        /chain-network/container-chain-template-frontier-node-znver3 \
+        /chain-network/container-chain-frontier-node-znver3 \
         --8<-- 'code/node-operators/appchain-node/rpc-docker/docker-command.md'
         ```
 
@@ -91,7 +91,7 @@ To spin up your node, you must run the Docker image with the `docker run` comman
 
         ```bash
         docker run -ti moondancelabs/dancebox-container-chain-simple-templates \
-        /chain-network/container-chain-template-simple-node \
+        /chain-network/container-chain-simple-node \
         --8<-- 'code/node-operators/appchain-node/rpc-docker/docker-command.md'
         ```
 
@@ -99,7 +99,7 @@ To spin up your node, you must run the Docker image with the `docker run` comman
     
         ```bash
         docker run -ti moondancelabs/dancebox-container-chain-simple-templates \
-        /chain-network/container-chain-template-simple-node-skylake \
+        /chain-network/container-chain-simple-node-skylake \
         --8<-- 'code/node-operators/appchain-node/rpc-docker/docker-command.md'
         ```
     
@@ -107,7 +107,7 @@ To spin up your node, you must run the Docker image with the `docker run` comman
     
         ```bash
         docker run -ti moondancelabs/dancebox-container-chain-simple-templates \
-        /chain-network/container-chain-template-simple-node-znver3 \
+        /chain-network/container-chain-simple-node-znver3 \
         --8<-- 'code/node-operators/appchain-node/rpc-docker/docker-command.md'
         ```
 
@@ -122,7 +122,7 @@ The following example spins up a full archive RPC node for the [demo EVM appchai
 
 ```bash
 docker run -ti moondancelabs/dancebox-container-chain-evm-templates \
-/chain-network/container-chain-template-frontier-node \
+/chain-network/container-chain-frontier-node \
 --chain=/chain-network/container-3001-raw-specs.json \
 --rpc-port=9944 \
 --name=para \
@@ -153,7 +153,7 @@ The flags used in the `docker run` command can be adjusted according to your pre
 
 ```bash
 docker run -ti moondancelabs/dancebox-container-chain-evm-templates \
-/chain-network/container-chain-template-frontier-node \
+/chain-network/container-chain-frontier-node \
 --help
 ```
 

--- a/node-operators/appchain-node/rpc-systemd.md
+++ b/node-operators/appchain-node/rpc-systemd.md
@@ -35,15 +35,15 @@ Every new release includes two node binaries, one for EVM-compatible appchains a
 === "EVM-Compatible Appchain"
 
     ```bash
-    wget https://github.com/moondance-labs/tanssi/releases/latest/download/container-chain-template-frontier-node && \
-    chmod +x ./container-chain-template-frontier-node
+    wget https://github.com/moondance-labs/tanssi/releases/latest/download/container-chain-frontier-node && \
+    chmod +x ./container-chain-frontier-node
     ```
 
 === "Substrate Appchain"
 
     ```bash
-    wget https://github.com/moondance-labs/tanssi/releases/latest/download/container-chain-template-simple-node && \
-    chmod +x ./container-chain-template-simple-node
+    wget https://github.com/moondance-labs/tanssi/releases/latest/download/container-chain-simple-node && \
+    chmod +x ./container-chain-simple-node
     ```
 
 --8<-- 'text/node-operators/optimized-binaries-note.md'
@@ -123,7 +123,7 @@ Note that the `ExecStart` command  has some parameters that need to be changed t
     SyslogIdentifier=appchain
     SyslogFacility=local7
     KillSignal=SIGHUP
-    ExecStart=/var/lib/appchain-data/container-chain-template-frontier-node \
+    ExecStart=/var/lib/appchain-data/container-chain-frontier-node \
     --chain=YOUR_APPCHAIN_SPECS_FILE_LOCATION \
     --rpc-port=9944 \
     --name=para \
@@ -163,7 +163,7 @@ Note that the `ExecStart` command  has some parameters that need to be changed t
     SyslogIdentifier=appchain
     SyslogFacility=local7
     KillSignal=SIGHUP
-    ExecStart=/var/lib/appchain-data/container-chain-template-simple-node \
+    ExecStart=/var/lib/appchain-data/container-chain-simple-node \
     --chain=YOUR_APPCHAIN_SPECS_FILE_LOCATION \
     --rpc-port=9944 \
     --name=para \
@@ -209,7 +209,7 @@ User=appchain_node_service
 SyslogIdentifier=appchain
 SyslogFacility=local7
 KillSignal=SIGHUP
-ExecStart=/var/lib/appchain-data/container-chain-template-frontier-node \
+ExecStart=/var/lib/appchain-data/container-chain-frontier-node \
 --chain=/var/lib/appchain-data/container-3001-raw-specs.json \
 --rpc-port=9944 \
 --name=para \
@@ -244,13 +244,13 @@ The flags used in the `ExecStart` command can be adjusted according to your pref
 === "EVM-compatible Appchain"
 
     ```bash
-    /var/lib/appchain-data/container-chain-template-frontier-node --help
+    /var/lib/appchain-data/container-chain-frontier-node --help
     ```
 
 === "Simple Substrate Appchain"
 
     ```bash
-    /var/lib/appchain-data/container-chain-template-simple-node --help
+    /var/lib/appchain-data/container-chain-simple-node --help
     ```
 
 ## Run the Service {: #run-the-service }


### PR DESCRIPTION
### Description

This PR updates the template names, changed in the latest release:
container-chain-template-frontier-node -> container-chain-frontier-node
container-chain-template-simple-node -> container-chain-simple-node

It updates the guides for RPC nodes operators

### Checklist

- [ ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
