### PR TITLE
Adding node key step for block producers

### DIFF
--- a/.snippets/code/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker/docker-command.md
+++ b/.snippets/code/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker/docker-command.md
@@ -7,6 +7,7 @@
 --collator \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --database paritydb \
+--node-key-file /data/node-key \
 -- \
 --name=INSERT_YOUR_BLOCK_PRODUCER_NODE_NAME \
 --base-path=/data/container \

--- a/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/generate-node-key-intro.md
+++ b/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/generate-node-key-intro.md
@@ -1,0 +1,1 @@
+Starting from [runtime 700 release](https://github.com/moondance-labs/tanssi/releases/tag/runtime-700){target=\_blank}, Tanssi block producer nodes don't generate the session keys automatically on start-up. To generate and store on disk the session keys that will be referenced on the start-up command, run the following command:

--- a/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/generate-node-key-unsafe-note.md
+++ b/.snippets/text/node-operators/block-producers/onboarding/run-a-block-producer/generate-node-key-unsafe-note.md
@@ -1,0 +1,2 @@
+!!! note
+    This step could be avoided using the `--unsafe-force-node-key-generation` parameter in the start-up command, although this is not the recommended practice.

--- a/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker.md
+++ b/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-docker.md
@@ -58,6 +58,18 @@ sudo chown -R $(id -u):$(id -g) /var/lib/dancebox
 !!! note
     The directory is a parameter in the Docker start-up command. If you decide to create the directory elsewhere, update the command accordingly.
 
+### Generate the Node Key {: #generate-node-key }
+
+--8<-- 'text/node-operators/block-producers/onboarding/run-a-block-producer/generate-node-key-intro.md'
+
+```bash
+docker run --network="host" -v "/var/lib/dancebox:/data" \
+-u $(id -u ${USER}):$(id -g ${USER}) \
+moondancelabs/tanssi key generate-node-key --file /data/node-key
+```
+
+--8<-- 'text/node-operators/block-producers/onboarding/run-a-block-producer/generate-node-key-unsafe-note.md'
+
 ## Start-Up Command {: #start-up-command }
 
 To spin up your node, you must run the Docker image with the `docker run` command. 

--- a/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
+++ b/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
@@ -21,7 +21,6 @@ To get started, you'll need access to a computer running an Ubuntu Linux OS and 
 
 - **Node binary file** - the instructions in this guide execute the [latest](https://github.com/moondance-labs/tanssi/releases/latest){target=\_blank} official stable `tanssi-node` release. However, you can build your own file compiling the [source code](https://github.com/moondance-labs/tanssi){target=\_blank}
 
-
 ## Download the Latest Release {: #download-latest-release }
 
 To get started, download and make executable the latest binary release by running the following command:
@@ -79,6 +78,16 @@ And finally, move the binary to the folder:
 mv ./tanssi-node /var/lib/tanssi-data
 ```
 
+### Generate the Node Key {: #generate-node-key }
+
+--8<-- 'text/node-operators/block-producers/onboarding/run-a-block-producer/generate-node-key-intro.md'
+
+```bash
+/var/lib/tanssi-data key generate-node-key --file /var/lib/tanssi-data/node-key
+```
+
+--8<-- 'text/node-operators/block-producers/onboarding/run-a-block-producer/generate-node-key-unsafe-note.md'
+
 ### Create the Systemd Service Configuration File {: #create-systemd-configuration }
 
 The next step is to create the Systemd configuration file.
@@ -114,7 +123,8 @@ ExecStart=/var/lib/tanssi-data/tanssi-node \
 --blocks-pruning=2000 \
 --collator \
 --database paritydb \
---telemetry-url='wss://telemetry.polkadot.io/submit/ 0' 
+--telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
+--node-key-file /var/lib/tanssi-data/node-key \
 -- \
 --name=INSERT_YOUR_BLOCK_PRODUCER_NODE_NAME \
 --base-path=/var/lib/tanssi-data/container \


### PR DESCRIPTION
### Description

This PR adds a step to run block producers nodes without getting a startup exception

### Checklist

- [x] I have added a label to this PR 🏷️
- [x] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
