### PR TITLE
fix typo

### DIFF
--- a/builders/tanssi-network/testnet/demo-evm-appchain.md
+++ b/builders/tanssi-network/testnet/demo-evm-appchain.md
@@ -52,7 +52,7 @@ For the demo EVM appchain, you can use any of the following explorers:
 
 - [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://fraa-dancebox-3001-rpc.a.dancebox.tanssi.network#/explorer){target=\_blank} (Substrate API)
 - [Blockscout](https://fra-dancebox-3001-bs.a.dancebox.tanssi.network){target=\_blank} (Ethereum API)
-- [Expedition](https://tanssi-evmexplorer.netlify.app){target=\_blank}{target=\_blank} (Ethereum API)
+- [Expedition](https://tanssi-evmexplorer.netlify.app){target=\_blank} (Ethereum API)
 
 ## Chain ID {: #chain-id }
 


### PR DESCRIPTION
### Description

Fixes typo with a duplication of target blank.

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
