### PR TITLE
updates generate node key command to call binary

### DIFF
--- a/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
+++ b/node-operators/block-producers/onboarding/run-a-block-producer/block-producer-systemd.md
@@ -83,7 +83,7 @@ mv ./tanssi-node /var/lib/tanssi-data
 --8<-- 'text/node-operators/block-producers/onboarding/run-a-block-producer/generate-node-key-intro.md'
 
 ```bash
-/var/lib/tanssi-data key generate-node-key --file /var/lib/tanssi-data/node-key
+/var/lib/tanssi-data/tanssi-node key generate-node-key --file /var/lib/tanssi-data/node-key
 ```
 
 --8<-- 'text/node-operators/block-producers/onboarding/run-a-block-producer/generate-node-key-unsafe-note.md'


### PR DESCRIPTION
### Description

This PR adds the binary to the generate-node-key command to conform to the new requirement for new node operators to generate a key before startup.

### Checklist

- [ x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
