### PR TITLE
Revisit erc20 articles

### DIFF
--- a/builders/toolkit/ethereum-api/precompiles/erc20.md
+++ b/builders/toolkit/ethereum-api/precompiles/erc20.md
@@ -43,11 +43,11 @@ The [`ERC20.sol`](https://github.com/moondance-labs/tanssi/blob/master/test/cont
 
 To follow along with this tutorial, you will need to have your wallet configured to work with your EVM appchain and an account funded with native tokens. You can add your EVM appchain to MetaMask with one click on the [Tanssi dApp](https://apps.tanssi.network){target=\_blank}. Or, you can [configure MetaMask for Tanssi with the demo EVM appchain](/builders/toolkit/ethereum-api/wallets/metamask/){target=\_blank}.
 
-### Add Token to MetaMask {: #add-token-to-metamask }
+### Add Token to an EVM Wallet {: #add-token-to-evm-wallet }
 
-If you want to interact with your appchain's native token like you would with an ERC-20 in MetaMask, you can add a custom token to your wallet using the precompile address.
+If you want to interact with your appchain's native token like you would with an ERC-20, you can add a custom token to your EVM-compatible wallet using the precompile address. This section will walk you through adding an external asset to [MetaMask](/builders/toolkit/ethereum-api/wallets/metamask/){target=\_blank}.
 
-To get started, open up MetaMask and make sure you are [connected to your appchain](/builders/toolkit/ethereum-api/wallets/metamask/) and:
+To get started, open up MetaMask and make sure you are connected to your appchain and:
 
 1. Switch to the **Assets** tab
 2. Click on **Import tokens**

--- a/builders/toolkit/ethereum-api/precompiles/external-assets-erc20.md
+++ b/builders/toolkit/ethereum-api/precompiles/external-assets-erc20.md
@@ -30,7 +30,7 @@ For example, for the asset whose ID is `1`, the last four positions must be repl
  
 - Access to a Tanssi EVM appchain running [runtime 500](https://github.com/moondance-labs/tanssi/releases/tag/runtime-500){target=\_blank} or above
 - An established bidirectional XCM channel to another chain. To manage your appchain's channels, refer to the [Manage Cross-Chain Communication Channels](/builders/manage/dapp/xcm-channels/){target=\_blank} article
-- A registered external asset. Once the XCM channels are open, asset registration can be easily done using the [dApp](https://apps.tanssi.network/){target=\_blank}, in the `Asset Registration` menu entry from the `XCM` management section
+- A registered external asset. Once the XCM channels are open, asset registration can be easily done using the [dApp](https://apps.tanssi.network/){target=\_blank} as explained in the [Register External Assets](/builders/manage/dapp/register-external-assets/){target=\_blank} guide
 - Finally, you'll need an [EVM-compatible wallet](/builders/toolkit/ethereum-api/wallets/){target=\_blank} configured to work with your appchain. You can also connect your wallet to the [demo EVM appchain](https://apps.tanssi.network/demo){target=\_blank}.
 
 The examples in this guide are based on the Tanssi demo EVM appchain, which already has open channels to other appchains and registered external assets, as the following picture shows:


### PR DESCRIPTION
### Description

This PR adds a link from the precompile external assets article to the already published guide of registering external assets using the dapp.
It also changes the wording in the ERC 20 native token precompile guide to make metamask as an example of an evm compatible wallet

### Checklist

- [ ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
