### PR TITLE
builder - substrate template generalization

### DIFF
--- a/builders/build/templates/substrate.md
+++ b/builders/build/templates/substrate.md
@@ -23,7 +23,7 @@ Since the provided template already includes the essential configurations for se
 Here are some of the features that come with this template:
 
 - Utilize Tanssi's [block production as a service](/learn/tanssi/technical-features/#block-production-as-a-service){target=\_blank}
-- Leverage Ethereum-grade security from [Symbiotic](https://symbiotic.fi/){target=\_blank}
+- Choose the security provider that best fits your needs. For example, leverage Ethereum-grade security from [Symbiotic](https://symbiotic.fi/){target=\_blank}
 - Get deterministic transaction finality in seconds
 - Build dApps interacting with your appchain through an [API](/builders/toolkit/substrate-api/libraries/polkadot-js-api/){target=\_blank}
 

--- a/builders/build/templates/substrate.md
+++ b/builders/build/templates/substrate.md
@@ -1,31 +1,31 @@
 ---
 title: Baseline Appchain Template
-description: The Tanssi repository includes a basic Substrate-oriented template that provides the necessary configuration to kick-start the development of an appchain.
+description: The Tanssi repository includes a basic template that provides the necessary configuration to support the protocol and kick-start the development of an appchain.
 ---
 
 # Baseline Appchain Template {: #baseline-appchain-template }
 
 ## Introduction {: #introduction }
 
-The Tanssi repository includes a bare minimum Substrate template that provides the necessary configuration to support the Tanssi protocol and some essential modules, such as the one that allows handling the Tanssi appchain's currency.
+The Tanssi repository includes a bare minimum template that provides the necessary configuration to support the Tanssi protocol and some essential modules, such as the one that allows handling the Tanssi appchain's currency.
 
 This section covers this basic template, what it includes, and some aspects to consider when adding external dependencies.
 
 ## Baseline Appchain Template {: #baseline-appchain-template }
 
-Developing a Substrate-based runtime typically involves two primary steps:
+Developing an appchain runtime typically involves two primary steps:
 
-1. [Incorporating pre-existing Substrate built-in modules](/builders/build/customize/adding-built-in-module/){target=\_blank} into the runtime
+1. [Incorporating pre-existing built-in modules](/builders/build/customize/adding-built-in-module/){target=\_blank} into the runtime
 2. [Creating custom modules](/builders/build/customize/adding-custom-made-module/){target=\_blank} tailored to your specific application needs
 
-Since the provided template already includes the essential configurations for seamless integration into the Polkadot ecosystem and compatibility with the Tanssi protocol, teams interested in constructing an innovative Tanssi appchain can use this template as a starting point for adding their custom logic.
+Since the provided template already includes the essential configurations for seamless integration with the Tanssi protocol and the security provider (for example, [Symbiotic](https://symbiotic.fi/){target=\_blank} on Ethereum), teams interested in constructing an innovative Tanssi appchain can use this template as a starting point for adding their custom logic.
 
 Here are some of the features that come with this template:
 
 - Utilize Tanssi's [block production as a service](/learn/tanssi/technical-features/#block-production-as-a-service){target=\_blank}
-- Use [Polkadot's finality gadget](https://wiki.polkadot.network/docs/learn-consensus#finality-gadget-grandpa){target=\_blank}
-- Benefit from [Polkadot's shared security model](https://wiki.polkadot.network/docs/learn-parachains#shared-security){target=\_blank}
-- Use the [Polkadot.js API](/builders/toolkit/substrate-api/libraries/polkadot-js-api/){target=\_blank} to interact with the Substrate API
+- Leverage Ethereum-grade security from [Symbiotic](https://symbiotic.fi/){target=\_blank}
+- Get deterministic transaction finality in seconds
+- Build dApps interacting with your appchain through an [API](/builders/toolkit/substrate-api/libraries/polkadot-js-api/){target=\_blank}
 
 By leveraging these features in the template, you can kickstart your Tanssi appchain development and customize it to meet your specific requirements and innovations.
 
@@ -33,4 +33,4 @@ By leveraging these features in the template, you can kickstart your Tanssi appc
 
 The Substrate appchain template includes all the required modules and configurations that make it compatible with the Tanssi protocol, and also [many other modules](/builders/build/templates/overview/#included-modules){target=\_blank} that provide basic functionalities.
 
-This template is meant to be built on top of it, as most use cases require expanded capabilities, adding existing or custom modules. To learn how to add new functionalities to your runtime, check the [customize runtime](/builders/build/customize/){target=\_blank} section.
+This template is designed to serve as a foundation to build upon, as most use cases require expanded capabilities, adding existing or custom modules. To learn how to add new functionalities to your runtime, check the [customize runtime](/builders/build/customize/){target=\_blank} section.


### PR DESCRIPTION
### Description

This PR generalizes the substrate template.
It basically removes substrate references and proposes symbiotic as the to-go choice for a security model

### Checklist

- [ ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `tanssi-mkdocs` to update redirects
