### PR TITLE
fix: code snipet in adding external module

### DIFF
--- a/builders/build/customize/adding-external-module.md
+++ b/builders/build/customize/adding-external-module.md
@@ -111,9 +111,9 @@ Next, add the following snippet to the `lib.rs` file inside the runtime folder. 
 
 ```rust
 ...
-impl pallet_template::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = pallet_template::weights::SubstrateWeight<Runtime>;
+impl pallet_toggle::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = pallet_toggle::weights::SubstrateWeight<Runtime>;
 }
 
 construct_runtime!(


### PR DESCRIPTION
### Description

This PR fix a code snippet in the [adding-external-module.md](https://github.com/moondance-labs/tanssi-docs/compare/main...ernestosperanza:tanssi-docs:ernestosperanza/fix/fix-code-snipet?expand=1#diff-ef42f4f2c79b3bec1e2590832502e6ec6e7a783b671849f529ac74b462cb76a5)

### Checklist

- [x] I have added a label to this PR 🏷️
- [x] I have run my changes through Grammarly
- [x] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `tanssi-mkdocs` to update redirects
