### PR TITLE
Update validators-systemd.md

### DIFF
--- a/node-operators/validators/onboarding/run-a-validator/validators-systemd.md
+++ b/node-operators/validators/onboarding/run-a-validator/validators-systemd.md
@@ -65,9 +65,9 @@ To get started, download the latest binary release and make it executable by run
 === "AMD Zen3"
 
     ```bash
-    wget https://github.com/moondance-labs/tanssi/releases/download/{{ networks.dancebox.client_version }}/tanssi-relay-znver3 -O tanssi-node && \
-    wget https://github.com/moondance-labs/tanssi/releases/download/{{ networks.dancebox.client_version }}/tanssi-relay-execute-worker-znver3 -O tanssi-node && \
-    wget https://github.com/moondance-labs/tanssi/releases/download/{{ networks.dancebox.client_version }}/tanssi-relay-prepare-worker-znver3 -O tanssi-node && \
+    wget https://github.com/moondance-labs/tanssi/releases/download/{{ networks.dancebox.client_version }}/tanssi-relay-znver3 -O tanssi-relay-znver && \
+    wget https://github.com/moondance-labs/tanssi/releases/download/{{ networks.dancebox.client_version }}/tanssi-relay-execute-worker-znver3 -O tanssi-relay-execute-worker-znver && \
+    wget https://github.com/moondance-labs/tanssi/releases/download/{{ networks.dancebox.client_version }}/tanssi-relay-prepare-worker-znver3 -O tanssi-relay-prepare-worker-znver && \
     chmod +x ./tanssi-relay*
     ```
 


### PR DESCRIPTION
fixed AMD Zen3 section that rewrote all 3 binaries incorrectly as "tanssi-node"

### Description

fixed AMD Zen3 section that rewrote all 3 binaries incorrectly as "tanssi-node"

### Checklist

- [ ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `tanssi-mkdocs` to update redirects
