### PR TITLE
Fix typo 

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -20492,7 +20492,7 @@ And the output looks like:
 
 ## Submit Metadata {: #submitting-metadata }
 
-Once your operator is successfully registered, you can add metadata (e.g., logo) to improve its visibility on the [Symbiotic website](httos://app.symbiotic.fi){target=\_blank}.
+Once your operator is successfully registered, you can add metadata (e.g., logo) to improve its visibility on the [Symbiotic website](https://app.symbiotic.fi){target=\_blank}.
 
 To submit your operator's metadata, head to the Symbiotic metadata repository:
 

--- a/node-operators/validators/onboarding/register-in-symbiotic.md
+++ b/node-operators/validators/onboarding/register-in-symbiotic.md
@@ -145,7 +145,7 @@ And the output looks like:
 
 ## Submit Metadata {: #submitting-metadata }
 
-Once your operator is successfully registered, you can add metadata (e.g., logo) to improve its visibility on the [Symbiotic website](httos://app.symbiotic.fi){target=\_blank}.
+Once your operator is successfully registered, you can add metadata (e.g., logo) to improve its visibility on the [Symbiotic website](https://app.symbiotic.fi){target=\_blank}.
 
 To submit your operator's metadata, head to the Symbiotic metadata repository:
 


### PR DESCRIPTION
### Description

This minor PR corrects a typo in the symbiotic URL found in the register-in-symbiotic.md content page.

### Checklist

- [ ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `tanssi-mkdocs` to update redirects
