### PR TITLE
fix wrong placement of argument '--chain sepolia'

### DIFF
--- a/node-operators/operators/onboarding/opt-in-to-tanssi.md
+++ b/node-operators/operators/onboarding/opt-in-to-tanssi.md
@@ -40,7 +40,7 @@ If you have correctly installed the [Symbiotic CLI](#set-up-the-cli) and you wan
 === "TestNet (Sepolia)"
 
     ```bash
-    python3 symb.py opt-in-vault {{ networks.symbiotic.contracts.sepolia.vault }} --ledger --ledger-account INSERT_OPERATOR_ADDRESS --chain sepolia
+    python3 symb.py --chain sepolia opt-in-vault {{ networks.symbiotic.contracts.sepolia.vault }} --ledger --ledger-account INSERT_OPERATOR_ADDRESS
     ```
 
 If you want to sign the transaction directly using the operator's account private key, then run the following command, replacing the `INSERT_PRIVATE_KEY` parameter:
@@ -54,7 +54,7 @@ If you want to sign the transaction directly using the operator's account privat
 === "TestNet (Sepolia)"
 
     ```bash
-    python3 symb.py opt-in-vault {{ networks.symbiotic.contracts.sepolia.vault }} --private-key INSERT_PRIVATE_KEY --chain sepolia
+    python3 symb.py --chain sepolia opt-in-vault {{ networks.symbiotic.contracts.sepolia.vault }} --private-key INSERT_PRIVATE_KEY
     ```
 
 !!! warning
@@ -137,7 +137,7 @@ You can also verify your registration status using the Symbiotic CLI running the
 === "TestNet (Sepolia)"
 
     ```bash
-    python3 symb.py check-opt-in-vault INSERT_OPERATOR_ADDRESS {{ networks.symbiotic.contracts.sepolia.vault }} --chain sepolia
+    python3 symb.py --chain sepolia check-opt-in-vault INSERT_OPERATOR_ADDRESS {{ networks.symbiotic.contracts.sepolia.vault }}
     ```
 
 And the output looks like:
@@ -169,7 +169,7 @@ If you have correctly installed the [Symbiotic CLI](#set-up-the-cli) and you wan
 === "TestNet (Sepolia)"
 
     ```bash
-    python3 symb.py opt-in-network {{ networks.symbiotic.contracts.sepolia.tanssi_network }} --ledger --ledger-account INSERT_OPERATOR_ADDRESS --chain sepolia
+    python3 symb.py --chain sepolia opt-in-network {{ networks.symbiotic.contracts.sepolia.tanssi_network }} --ledger --ledger-account INSERT_OPERATOR_ADDRESS
     ```
 
 If you want to sign the transaction directly using the operator's account private key, then run the following command, replacing the `INSERT_PRIVATE_KEY` parameter:
@@ -183,7 +183,7 @@ If you want to sign the transaction directly using the operator's account privat
 === "TestNet (Sepolia)"
 
     ```bash
-    python3 symb.py opt-in-network {{ networks.symbiotic.contracts.sepolia.tanssi_network }} --private-key INSERT_PRIVATE_KEY --chain sepolia
+    python3 symb.py --chain sepolia opt-in-network {{ networks.symbiotic.contracts.sepolia.tanssi_network }} --private-key INSERT_PRIVATE_KEY
     ```
 
 !!! warning
@@ -266,7 +266,7 @@ You can also verify your registration status using the Symbiotic CLI running the
 === "TestNet (Sepolia)"
 
     ```bash
-    python3 symb.py check-opt-in-network INSERT_OPERATOR_ADDRESS {{ networks.symbiotic.contracts.sepolia.tanssi_network }} --chain sepolia
+    python3 symb.py --chain sepolia check-opt-in-network INSERT_OPERATOR_ADDRESS {{ networks.symbiotic.contracts.sepolia.tanssi_network }} 
     ```
 
 And the output looks like:

--- a/node-operators/operators/onboarding/register-in-symbiotic.md
+++ b/node-operators/operators/onboarding/register-in-symbiotic.md
@@ -36,7 +36,7 @@ If you correctly installed the [Symbiotic CLI](#set-up-the-cli) and you want to 
 === "TestNet (Sepolia)"
 
     ```bash
-    python3 symb.py register-operator --ledger --ledger-account INSERT_OPERATOR_ADDRESS --chain sepolia
+    python3 symb.py --chain sepolia register-operator --ledger --ledger-account INSERT_OPERATOR_ADDRESS 
     ```
 
 If you want to sign the transaction directly using the account private key, then run the following command, replacing the `INSERT_PRIVATE_KEY` parameter:
@@ -50,7 +50,7 @@ If you want to sign the transaction directly using the account private key, then
 === "TestNet (Sepolia)"
 
     ```bash
-    python3 symb.py register-operator --private-key INSERT_PRIVATE_KEY --chain sepolia
+    python3 symb.py --chain sepolia register-operator --private-key INSERT_PRIVATE_KEY
     ```
 
 !!! warning
@@ -131,7 +131,7 @@ You can also verify your registration status using the Symbiotic CLI running the
 === "TestNet (Sepolia)"
 
     ```bash
-    python3 symb.py isop INSERT_OPERATOR_ADDRESS --chain sepolia
+    python3 symb.py --chain sepolia isop INSERT_OPERATOR_ADDRESS 
     ```
 
 And the output looks like:


### PR DESCRIPTION
### Description

Please explain the changes this PR addresses here.

fix wrong placement of argument '--chain sepolia' 
should be placed after symb.py instead of the end of the cli command

### Checklist

- [ ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `tanssi-mkdocs` to update redirects
