### PR TITLE
Applies feedback for collator guides

### DIFF
--- a/.snippets/code/node-operators/sequencers/onboarding/run-a-sequencer/sequencers-docker/docker-command.md
+++ b/.snippets/code/node-operators/sequencers/onboarding/run-a-sequencer/sequencers-docker/docker-command.md
@@ -1,15 +1,10 @@
 --name=INSERT_YOUR_SEQUENCER_NODE_NAME \
 --base-path=/data/container \
 --node-key-file=/data/node-key \
---keystore-path=/data/keys/session \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --pool-type=fork-aware \
 --database=paritydb \
 --rpc-port=9944 \
---rpc-cors=all \
---rpc-max-connections 100 \
---unsafe-rpc-external \
---rpc-methods=unsafe \
 --prometheus-port=9615 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30333 \
@@ -26,11 +21,9 @@
 --sync=fast \
 --base-path=/data/relay \      
 --node-key-file=/data/node-key \
+--keystore-path=/data/keys/session \
 --database=paritydb \
 --rpc-port=9945 \
---rpc-cors=all \
---rpc-methods=safe \
---unsafe-rpc-external \
 --prometheus-port=9616 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30334 \

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -22337,10 +22337,10 @@ You will need to create session keys for your primary and backup servers. Each o
 
 Before generating session keys, you must be [running a sequencer node](/node-operators/sequencers/onboarding/run-a-sequencer/){target=\_blank}.
 
-To generate session keys, you'll send an RPC call, using the `author_rotateKeys` method, to your node's HTTP endpoint. For reference, if your sequencer's HTTP endpoint is at port `9944`, the JSON-RPC call might look like this:
+To generate session keys, you'll send an RPC call, using the `author_rotateKeys` method, to your node's HTTP endpoint. For reference, if your sequencer's HTTP endpoint is at port `9945`, the JSON-RPC call might look like this:
 
 ```bash
-curl http://127.0.0.1:9944 -H \
+curl http://127.0.0.1:9945 -H \
 "Content-Type:application/json;charset=utf-8" -d \
   '{
     "jsonrpc":"2.0",
@@ -22662,15 +22662,10 @@ Name each of the sections with a human-readable name by replacing the `INSERT_YO
     --name=INSERT_YOUR_SEQUENCER_NODE_NAME \
 --base-path=/data/container \
 --node-key-file=/data/node-key \
---keystore-path=/data/keys/session \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --pool-type=fork-aware \
 --database=paritydb \
 --rpc-port=9944 \
---rpc-cors=all \
---rpc-max-connections 100 \
---unsafe-rpc-external \
---rpc-methods=unsafe \
 --prometheus-port=9615 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30333 \
@@ -22687,11 +22682,9 @@ Name each of the sections with a human-readable name by replacing the `INSERT_YO
 --sync=fast \
 --base-path=/data/relay \      
 --node-key-file=/data/node-key \
+--keystore-path=/data/keys/session \
 --database=paritydb \
 --rpc-port=9945 \
---rpc-cors=all \
---rpc-methods=safe \
---unsafe-rpc-external \
 --prometheus-port=9616 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30334 \
@@ -22715,15 +22708,10 @@ Name each of the sections with a human-readable name by replacing the `INSERT_YO
     --name=INSERT_YOUR_SEQUENCER_NODE_NAME \
 --base-path=/data/container \
 --node-key-file=/data/node-key \
---keystore-path=/data/keys/session \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --pool-type=fork-aware \
 --database=paritydb \
 --rpc-port=9944 \
---rpc-cors=all \
---rpc-max-connections 100 \
---unsafe-rpc-external \
---rpc-methods=unsafe \
 --prometheus-port=9615 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30333 \
@@ -22740,11 +22728,9 @@ Name each of the sections with a human-readable name by replacing the `INSERT_YO
 --sync=fast \
 --base-path=/data/relay \      
 --node-key-file=/data/node-key \
+--keystore-path=/data/keys/session \
 --database=paritydb \
 --rpc-port=9945 \
---rpc-cors=all \
---rpc-methods=safe \
---unsafe-rpc-external \
 --prometheus-port=9616 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30334 \
@@ -22766,15 +22752,10 @@ Name each of the sections with a human-readable name by replacing the `INSERT_YO
     --name=INSERT_YOUR_SEQUENCER_NODE_NAME \
 --base-path=/data/container \
 --node-key-file=/data/node-key \
---keystore-path=/data/keys/session \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --pool-type=fork-aware \
 --database=paritydb \
 --rpc-port=9944 \
---rpc-cors=all \
---rpc-max-connections 100 \
---unsafe-rpc-external \
---rpc-methods=unsafe \
 --prometheus-port=9615 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30333 \
@@ -22791,11 +22772,9 @@ Name each of the sections with a human-readable name by replacing the `INSERT_YO
 --sync=fast \
 --base-path=/data/relay \      
 --node-key-file=/data/node-key \
+--keystore-path=/data/keys/session \
 --database=paritydb \
 --rpc-port=9945 \
---rpc-cors=all \
---rpc-methods=safe \
---unsafe-rpc-external \
 --prometheus-port=9616 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30334 \
@@ -22939,7 +22918,7 @@ sudo chown -R tanssi_service /var/lib/tanssi-data
 Move the chain specification file to the folder:
 
 ```bash
-mv ./relay-raw-no-bootnodes-specs.json /var/lib/tanssi-data
+mv ./dancelight-raw-specs.json /var/lib/tanssi-data
 ```
 
 And finally, move the binary to the folder:
@@ -22989,15 +22968,10 @@ ExecStart=/var/lib/tanssi-data/tanssi-node solo-chain \
 --name=INSERT_YOUR_SEQUENCER_NODE_NAME \
 --base-path=/var/lib/tanssi-data/container \
 --node-key-file=/var/lib/tanssi-data/node-key \
---keystore-path=/var/lib/tanssi-data/session \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --pool-type=fork-aware \
 --database=paritydb \
 --rpc-port=9944 \
---rpc-cors=all \
---rpc-max-connections 100 \
---unsafe-rpc-external \
---rpc-methods=unsafe \
 --prometheus-port=9615 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30333 \
@@ -23009,16 +22983,14 @@ ExecStart=/var/lib/tanssi-data/tanssi-node solo-chain \
 --in-peers=100 \
 --detailed-log-output \
 -- \
---chain=/var/lib/tanssi-data/relay-raw-no-bootnodes-specs.json \
+--chain=/var/lib/tanssi-data/dancelight-raw-specs.json \
 --name=INSERT_YOUR_TANSSI_NODE_NAME \
 --sync=fast \
 --base-path=/var/lib/tanssi-data/relay \      
 --node-key-file=/var/lib/tanssi-data/node-key \
+--keystore-path=/var/lib/tanssi-data/session \
 --database=paritydb \
 --rpc-port=9945 \
---rpc-cors=all \
---rpc-methods=safe \
---unsafe-rpc-external \
 --prometheus-port=9616 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30334 \
@@ -23325,15 +23297,10 @@ To restart the node, you can use the same command you used when launching your n
     --name=INSERT_YOUR_SEQUENCER_NODE_NAME \
 --base-path=/data/container \
 --node-key-file=/data/node-key \
---keystore-path=/data/keys/session \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --pool-type=fork-aware \
 --database=paritydb \
 --rpc-port=9944 \
---rpc-cors=all \
---rpc-max-connections 100 \
---unsafe-rpc-external \
---rpc-methods=unsafe \
 --prometheus-port=9615 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30333 \
@@ -23350,11 +23317,9 @@ To restart the node, you can use the same command you used when launching your n
 --sync=fast \
 --base-path=/data/relay \      
 --node-key-file=/data/node-key \
+--keystore-path=/data/keys/session \
 --database=paritydb \
 --rpc-port=9945 \
---rpc-cors=all \
---rpc-methods=safe \
---unsafe-rpc-external \
 --prometheus-port=9616 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30334 \
@@ -23379,15 +23344,10 @@ To restart the node, you can use the same command you used when launching your n
     --name=INSERT_YOUR_SEQUENCER_NODE_NAME \
 --base-path=/data/container \
 --node-key-file=/data/node-key \
---keystore-path=/data/keys/session \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --pool-type=fork-aware \
 --database=paritydb \
 --rpc-port=9944 \
---rpc-cors=all \
---rpc-max-connections 100 \
---unsafe-rpc-external \
---rpc-methods=unsafe \
 --prometheus-port=9615 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30333 \
@@ -23404,11 +23364,9 @@ To restart the node, you can use the same command you used when launching your n
 --sync=fast \
 --base-path=/data/relay \      
 --node-key-file=/data/node-key \
+--keystore-path=/data/keys/session \
 --database=paritydb \
 --rpc-port=9945 \
---rpc-cors=all \
---rpc-methods=safe \
---unsafe-rpc-external \
 --prometheus-port=9616 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30334 \
@@ -23432,15 +23390,10 @@ To restart the node, you can use the same command you used when launching your n
     --name=INSERT_YOUR_SEQUENCER_NODE_NAME \
 --base-path=/data/container \
 --node-key-file=/data/node-key \
---keystore-path=/data/keys/session \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --pool-type=fork-aware \
 --database=paritydb \
 --rpc-port=9944 \
---rpc-cors=all \
---rpc-max-connections 100 \
---unsafe-rpc-external \
---rpc-methods=unsafe \
 --prometheus-port=9615 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30333 \
@@ -23457,11 +23410,9 @@ To restart the node, you can use the same command you used when launching your n
 --sync=fast \
 --base-path=/data/relay \      
 --node-key-file=/data/node-key \
+--keystore-path=/data/keys/session \
 --database=paritydb \
 --rpc-port=9945 \
---rpc-cors=all \
---rpc-methods=safe \
---unsafe-rpc-external \
 --prometheus-port=9616 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30334 \

--- a/node-operators/sequencers/onboarding/account-setup.md
+++ b/node-operators/sequencers/onboarding/account-setup.md
@@ -50,10 +50,10 @@ You will need to create session keys for your primary and backup servers. Each o
 
 Before generating session keys, you must be [running a sequencer node](/node-operators/sequencers/onboarding/run-a-sequencer/){target=\_blank}.
 
-To generate session keys, you'll send an RPC call, using the `author_rotateKeys` method, to your node's HTTP endpoint. For reference, if your sequencer's HTTP endpoint is at port `9944`, the JSON-RPC call might look like this:
+To generate session keys, you'll send an RPC call, using the `author_rotateKeys` method, to your node's HTTP endpoint. For reference, if your sequencer's HTTP endpoint is at port `9945`, the JSON-RPC call might look like this:
 
 ```bash
-curl http://127.0.0.1:9944 -H \
+curl http://127.0.0.1:9945 -H \
 "Content-Type:application/json;charset=utf-8" -d \
   '{
     "jsonrpc":"2.0",

--- a/node-operators/sequencers/onboarding/run-a-sequencer/sequencers-systemd.md
+++ b/node-operators/sequencers/onboarding/run-a-sequencer/sequencers-systemd.md
@@ -85,7 +85,7 @@ sudo chown -R tanssi_service /var/lib/tanssi-data
 Move the chain specification file to the folder:
 
 ```bash
-mv ./relay-raw-no-bootnodes-specs.json /var/lib/tanssi-data
+mv ./dancelight-raw-specs.json /var/lib/tanssi-data
 ```
 
 And finally, move the binary to the folder:
@@ -134,15 +134,10 @@ ExecStart=/var/lib/tanssi-data/tanssi-node solo-chain \
 --name=INSERT_YOUR_SEQUENCER_NODE_NAME \
 --base-path=/var/lib/tanssi-data/container \
 --node-key-file=/var/lib/tanssi-data/node-key \
---keystore-path=/var/lib/tanssi-data/session \
 --telemetry-url='wss://telemetry.polkadot.io/submit/ 0' \
 --pool-type=fork-aware \
 --database=paritydb \
 --rpc-port=9944 \
---rpc-cors=all \
---rpc-max-connections 100 \
---unsafe-rpc-external \
---rpc-methods=unsafe \
 --prometheus-port=9615 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30333 \
@@ -154,16 +149,14 @@ ExecStart=/var/lib/tanssi-data/tanssi-node solo-chain \
 --in-peers=100 \
 --detailed-log-output \
 -- \
---chain=/var/lib/tanssi-data/relay-raw-no-bootnodes-specs.json \
+--chain=/var/lib/tanssi-data/dancelight-raw-specs.json \
 --name=INSERT_YOUR_TANSSI_NODE_NAME \
 --sync=fast \
 --base-path=/var/lib/tanssi-data/relay \      
 --node-key-file=/var/lib/tanssi-data/node-key \
+--keystore-path=/var/lib/tanssi-data/session \
 --database=paritydb \
 --rpc-port=9945 \
---rpc-cors=all \
---rpc-methods=safe \
---unsafe-rpc-external \
 --prometheus-port=9616 \
 --prometheus-external \
 --listen-addr=/ip4/0.0.0.0/tcp/30334 \


### PR DESCRIPTION
### Description

- Following RT-1400, keystore-path parameter is relocated on the relay chain side for collators
- Replaces port called on rotate session keys action to 9945
- Fixes dancelight file specs name on systemd instructions
- Removes RPC parameters for collators

### Checklist

- [ ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `tanssi-mkdocs` to update redirects
