### PR TITLE
Allowlist Modification 

### DIFF
--- a/js/externalLinkModal.js
+++ b/js/externalLinkModal.js
@@ -65,7 +65,6 @@ const tanssiLinks = [
   origin,
   'https://www.tanssi.network',
   'https://tanssi.network',
-  'https://www.tanssi.network',
   'https://apps.tanssi.network/'
 ];
 const checkIfTanssiLink = (href) => {


### PR DESCRIPTION
This pull request makes a minor update to the list of trusted external links in `js/externalLinkModal.js`, ensuring that the modal does not appear for an additional domain.

* Added `'https://www.tanssi.network'` to the `moonbeamLinks` array to prevent the external link modal from showing for this domain.

### Checklist

- [x] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `tanssi-mkdocs` to update redirects
