### PR TITLE
Add Portuguese localized page and redirect support

### DIFF
--- a/i18n/en/LC_MESSAGES/messages.po
+++ b/i18n/en/LC_MESSAGES/messages.po
@@ -1,132 +1,23 @@
+# English translations for .
+# Copyright (C) 2026 ORGANIZATION
+# This file is distributed under the same license as the  project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: tanssi-docs\n"
+"Project-Id-Version:  tanssi-docs\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-01-30 13:33-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-msgid "meta.home_title"
-msgstr "Documentation for the Tanssi Network"
-
-msgid "footer.llms_full_label"
-msgstr "llms-full.txt"
-
-msgid "footer.made_with_html"
-msgstr ""
-"Made with 🩵 by <a href=\"https://papermoon.io/\" "
-"target=\"_blank\">PaperMoon</a>"
-
-msgid "footer.privacy_policy"
-msgstr "Privacy Policy"
-
-msgid "footer.terms_of_use"
-msgstr "Terms of Use"
-
-msgid "footer.material_attribution_html"
-msgstr ""
-"Made with <a href=\"https://squidfunk.github.io/mkdocs-material/\" "
-"target=\"_blank\" rel=\"noopener\">Material for MkDocs</a>"
-
-msgid "error.404_title"
-msgstr "404 – Not found"
-
-msgid "home.meta.title"
-msgstr "Tanssi Docs"
-
-msgid "home.hero.video_fallback"
-msgstr "Your browser does not support the video tag."
-
-msgid "home.hero.title_html"
-msgstr "Tanssi <span class=\"shadow\">&lt;Dev&gt;</span> Site"
-
-msgid "home.hero.subtitle"
-msgstr ""
-"Build, launch, and scale Symbiotic Networks faster with Tanssi's "
-"infrastructure, tools, and integrations."
-
-msgid "home.hero.cards.launch.title"
-msgstr "Launch a Tanssi-Powered Network"
-
-msgid "home.hero.cards.launch.description"
-msgstr "Get tools and guides to launch your network in minutes."
-
-msgid "home.hero.cards.launch.button"
-msgstr "Get Started"
-
-msgid "home.hero.cards.evm.title"
-msgstr "Develop using EVM Tools"
-
-msgid "home.hero.cards.evm.description"
-msgstr "Leverage popular EVM tools to accelerate your development."
-
-msgid "home.hero.cards.evm.button"
-msgstr "Learn More"
-
-msgid "home.hero.cards.learn.title"
-msgstr "Explore Technical Concepts"
-
-msgid "home.hero.cards.learn.description"
-msgstr "Learn Tanssi's features, services, and security via Symbiotic."
-
-msgid "home.hero.cards.learn.button"
-msgstr "Learn More"
-
-msgid "home.feature.heading.prefix"
-msgstr "The One Stop-Hub For Tanssi"
-
-msgid "home.feature.heading.accent"
-msgstr "Builders"
-
-msgid "home.feature.description"
-msgstr ""
-"Explore more ways to engage with the Tanssi ecosystem—access funding, "
-"resources, and visibility for your project."
-
-msgid "home.feature.cards.one.badge"
-msgstr "Ecosystem"
-
-msgid "home.feature.cards.one.title"
-msgstr "Apply for a Grant"
-
-msgid "home.feature.cards.one.arrow_alt"
-msgstr "Navigate to the Apply for a Grant page"
-
-msgid "home.feature.cards.two.badge"
-msgstr "Start Building"
-
-msgid "home.feature.cards.two.title"
-msgstr "Visit the TestNet"
-
-msgid "home.feature.cards.two.arrow_alt"
-msgstr "Navigate to the TestNet page"
-
-msgid "home.feature.cards.three.badge"
-msgstr "Industry Insights"
-
-msgid "home.feature.cards.three.title"
-msgstr "Ecosystem Updates"
-
-msgid "home.feature.cards.three.arrow_alt"
-msgstr "Navigate to the Ecosystem Updates page"
-
-msgid "home.feature.separator_alt"
-msgstr "Multicolor decorative design of Tanssi"
-
-msgid "home.community.heading.prefix"
-msgstr "Join the Tanssi"
-
-msgid "home.community.heading.accent"
-msgstr "Dev"
-
-msgid "home.community.heading.suffix"
-msgstr "Community"
-
-msgid "home.community.buttons.discord"
-msgstr "Join Discord"
-
-msgid "home.community.buttons.subscribe"
-msgstr "Subscribe"
+"Generated-By: Babel 2.15.0\n"
 
 msgid "action.edit"
 msgstr "Edit this page"
@@ -134,8 +25,23 @@ msgstr "Edit this page"
 msgid "action.view"
 msgstr "View source"
 
-msgid "feedback.title"
-msgstr "Was this page helpful?"
+msgid "disclaimer.third_party"
+msgstr "The information presented herein has been provided by third parties and is made available solely for general information purposes. Tanssi does not endorse any project listed and described on the Tanssi Doc Website (https://docs.tanssi.network/). Tanssi Foundation does not warrant the accuracy, completeness or usefulness of this information. Any reliance you place on such information is strictly at your own risk. Tanssi Foundation disclaims all liability and responsibility arising from any reliance placed on this information by you or by anyone who may be informed of any of its contents. All statements and/or opinions expressed in these materials are solely the responsibility of the person or entity providing those materials and do not necessarily represent the opinion of Tanssi Foundation. The information should not be construed as professional or financial advice of any kind. Advice from a suitably qualified professional should always be sought in relation to any particular matter or circumstance. The information herein may link to or integrate with other websites operated or content provided by third parties, and such other websites may link to this website. Tanssi Foundation has no control over any such other websites or their content and will have no liability arising out of or related to such websites or their content. The existence of any such link does not constitute an endorsement of such websites, the content of the websites, or the operators of the websites. These links are being provided to you only as a convenience and you release and hold Tanssi Foundation harmless from any and all liability arising from your use of this information or the information provided by any third-party website or service."
+
+msgid "error.404_title"
+msgstr "404 – Not found"
+
+msgid "external_link_modal.cancel"
+msgstr "Cancel"
+
+msgid "external_link_modal.continue"
+msgstr "Continue to External Site"
+
+msgid "external_link_modal.header"
+msgstr "You're Leaving the Tanssi Documentation Website"
+
+msgid "external_link_modal.message"
+msgstr "A new tab will open and you'll be sent to an independent, third-party website that is not affiliated with Tanssi."
 
 msgid "feedback.ratings.helpful.name"
 msgstr "This page was helpful"
@@ -147,52 +53,122 @@ msgid "feedback.ratings.unhelpful.name"
 msgstr "This page could be improved"
 
 msgid "feedback.ratings.unhelpful.note"
-msgstr ""
-"Thanks for your feedback! Help us improve this page by submitting <a "
-"href=\"https://github.com/moondance-labs/tanssi-"
-"docs/issues/new/?title=[Feedback]+{title}+-+{url}\" target=\"_blank\" "
-"rel=\"noopener\">additional feedback</a>."
+msgstr "Thanks for your feedback! Help us improve this page by submitting <a href=\"https://github.com/moondance-labs/tanssi-docs/issues/new/?title=[Feedback]+{title}+-+{url}\" target=\"_blank\" rel=\"noopener\">additional feedback</a>."
 
-msgid "disclaimer.third_party"
-msgstr ""
-"The information presented herein has been provided by third parties and is "
-"made available solely for general information purposes. Tanssi does not "
-"endorse any project listed and described on the Tanssi Doc Website "
-"(https://docs.tanssi.network/). Tanssi Foundation does not warrant the "
-"accuracy, completeness or usefulness of this information. Any reliance you "
-"place on such information is strictly at your own risk. Tanssi Foundation "
-"disclaims all liability and responsibility arising from any reliance placed "
-"on this information by you or by anyone who may be informed of any of its "
-"contents. All statements and/or opinions expressed in these materials are "
-"solely the responsibility of the person or entity providing those materials "
-"and do not necessarily represent the opinion of Tanssi Foundation. The "
-"information should not be construed as professional or financial advice of "
-"any kind. Advice from a suitably qualified professional should always be "
-"sought in relation to any particular matter or circumstance. The information"
-" herein may link to or integrate with other websites operated or content "
-"provided by third parties, and such other websites may link to this website."
-" Tanssi Foundation has no control over any such other websites or their "
-"content and will have no liability arising out of or related to such "
-"websites or their content. The existence of any such link does not "
-"constitute an endorsement of such websites, the content of the websites, or "
-"the operators of the websites. These links are being provided to you only as"
-" a convenience and you release and hold Tanssi Foundation harmless from any "
-"and all liability arising from your use of this information or the "
-"information provided by any third-party website or service."
+msgid "feedback.title"
+msgstr "Was this page helpful?"
 
-msgid "external_link_modal.header"
-msgstr "You're Leaving the Tanssi Documentation Website"
+msgid "footer.llms_full_label"
+msgstr "llms-full.txt"
 
-msgid "external_link_modal.message"
-msgstr ""
-"A new tab will open and you'll be sent to an independent, third-party "
-"website that is not affiliated with Tanssi."
+msgid "footer.made_with_html"
+msgstr "Made with 🩵 by <a href=\"https://papermoon.io/\" target=\"_blank\">PaperMoon</a>"
 
-msgid "external_link_modal.cancel"
-msgstr "Cancel"
+msgid "footer.material_attribution_html"
+msgstr "Made with <a href=\"https://squidfunk.github.io/mkdocs-material/\" target=\"_blank\" rel=\"noopener\">Material for MkDocs</a>"
 
-msgid "external_link_modal.continue"
-msgstr "Continue to External Site"
+msgid "footer.privacy_policy"
+msgstr "Privacy Policy"
+
+msgid "footer.terms_of_use"
+msgstr "Terms of Use"
+
+msgid "home.community.buttons.discord"
+msgstr "Join Discord"
+
+msgid "home.community.buttons.subscribe"
+msgstr "Subscribe"
+
+msgid "home.community.heading.accent"
+msgstr "Dev"
+
+msgid "home.community.heading.prefix"
+msgstr "Join the Tanssi"
+
+msgid "home.community.heading.suffix"
+msgstr "Community"
+
+msgid "home.feature.cards.one.arrow_alt"
+msgstr "Navigate to the Apply for a Grant page"
+
+msgid "home.feature.cards.one.badge"
+msgstr "Ecosystem"
+
+msgid "home.feature.cards.one.title"
+msgstr "Apply for a Grant"
+
+msgid "home.feature.cards.three.arrow_alt"
+msgstr "Navigate to the Ecosystem Updates page"
+
+msgid "home.feature.cards.three.badge"
+msgstr "Industry Insights"
+
+msgid "home.feature.cards.three.title"
+msgstr "Ecosystem Updates"
+
+msgid "home.feature.cards.two.arrow_alt"
+msgstr "Navigate to the TestNet page"
+
+msgid "home.feature.cards.two.badge"
+msgstr "Start Building"
+
+msgid "home.feature.cards.two.title"
+msgstr "Visit the TestNet"
+
+msgid "home.feature.description"
+msgstr "Explore more ways to engage with the Tanssi ecosystem—access funding, resources, and visibility for your project."
+
+msgid "home.feature.heading.accent"
+msgstr "Builders"
+
+msgid "home.feature.heading.prefix"
+msgstr "The One Stop-Hub For Tanssi"
 
 msgid "home.feature.heading.suffix"
 msgstr ""
+
+msgid "home.feature.separator_alt"
+msgstr "Multicolor decorative design of Tanssi"
+
+msgid "home.hero.cards.evm.button"
+msgstr "Learn More"
+
+msgid "home.hero.cards.evm.description"
+msgstr "Leverage popular EVM tools to accelerate your development."
+
+msgid "home.hero.cards.evm.title"
+msgstr "Develop using EVM Tools"
+
+msgid "home.hero.cards.launch.button"
+msgstr "Get Started"
+
+msgid "home.hero.cards.launch.description"
+msgstr "Get tools and guides to launch your network in minutes."
+
+msgid "home.hero.cards.launch.title"
+msgstr "Launch a Tanssi-Powered Network"
+
+msgid "home.hero.cards.learn.button"
+msgstr "Learn More"
+
+msgid "home.hero.cards.learn.description"
+msgstr "Learn Tanssi's features, services, and security via Symbiotic."
+
+msgid "home.hero.cards.learn.title"
+msgstr "Explore Technical Concepts"
+
+msgid "home.hero.subtitle"
+msgstr "Build, launch, and scale Symbiotic Networks faster with Tanssi's infrastructure, tools, and integrations."
+
+msgid "home.hero.title_html"
+msgstr "Tanssi <span class=\"shadow\">&lt;Dev&gt;</span> Site"
+
+msgid "home.hero.video_fallback"
+msgstr "Your browser does not support the video tag."
+
+msgid "home.meta.title"
+msgstr "Tanssi Docs"
+
+msgid "meta.home_title"
+msgstr "Documentation for the Tanssi Network"
+

--- a/i18n/pt/LC_MESSAGES/messages.po
+++ b/i18n/pt/LC_MESSAGES/messages.po
@@ -1,176 +1,23 @@
+# Portuguese translations for .
+# Copyright (C) 2026 ORGANIZATION
+# This file is distributed under the same license as the  project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: tanssi-docs\n"
+"Project-Id-Version:  tanssi-docs\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2026-01-30 13:33-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: pt\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Language-Team: pt <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-msgid "meta.home_title"
-msgstr "Documentação da rede Tanssi"
-
-msgid "footer.llms_full_label"
-msgstr "llms-full.txt"
-
-msgid "footer.made_with_html"
-msgstr ""
-"Feito com 🩵 por <a href=\"https://papermoon.io/\" "
-"target=\"_blank\">PaperMoon</a>"
-
-msgid "footer.privacy_policy"
-msgstr "Política de privacidade"
-
-msgid "footer.terms_of_use"
-msgstr "Termos de uso"
-
-msgid "footer.material_attribution_html"
-msgstr ""
-"Feito com <a href=\"https://squidfunk.github.io/mkdocs-material/\" "
-"target=\"_blank\" rel=\"noopener\">Material for MkDocs</a>"
-
-msgid "disclaimer.third_party"
-msgstr ""
-"As informações apresentadas aqui foram fornecidas por terceiros e estão "
-"disponíveis apenas para fins informativos gerais. A Tanssi não endossa "
-"nenhum projeto listado e descrito no Site de Documentação da Tanssi "
-"(https://docs.tanssi.network/). A Tanssi Foundation não garante a precisão, "
-"integridade ou utilidade dessas informações. Qualquer confiança depositada "
-"nelas é de sua exclusiva responsabilidade. A Tanssi Foundation se exime de "
-"toda responsabilidade decorrente de qualquer confiança que você ou qualquer "
-"outra pessoa possa ter em qualquer parte deste conteúdo. Todas as "
-"declarações e/ou opiniões expressas nesses materiais são de responsabilidade"
-" exclusiva da pessoa ou entidade que as fornece e não representam "
-"necessariamente a opinião da Tanssi Foundation. As informações aqui não "
-"devem ser interpretadas como aconselhamento profissional ou financeiro de "
-"qualquer tipo. Sempre busque orientação de um profissional devidamente "
-"qualificado em relação a qualquer assunto ou circunstância em particular. As"
-" informações aqui podem conter links ou integração com outros sites operados"
-" ou conteúdo fornecido por terceiros, e tais sites podem apontar para este "
-"site. A Tanssi Foundation não tem controle sobre esses sites ou seu conteúdo"
-" e não terá responsabilidade decorrente ou relacionada a eles. A existência "
-"de qualquer link não constitui endosso desses sites, de seu conteúdo ou de "
-"seus operadores. Esses links são fornecidos apenas para sua conveniência, e "
-"você isenta e exonera a Tanssi Foundation de qualquer responsabilidade "
-"decorrente do uso dessas informações ou das informações fornecidas por "
-"qualquer site ou serviço de terceiros."
-
-msgid "external_link_modal.header"
-msgstr "Você está saindo do site de documentação da Tanssi"
-
-msgid "external_link_modal.message"
-msgstr ""
-"Uma nova aba será aberta e você será direcionado a um site independente de "
-"terceiros, que não é afiliado à Tanssi."
-
-msgid "external_link_modal.cancel"
-msgstr "Cancelar"
-
-msgid "external_link_modal.continue"
-msgstr "Continuar para o site externo"
-
-msgid "error.404_title"
-msgstr "404 - Não encontrado"
-
-msgid "home.meta.title"
-msgstr "Tanssi Docs"
-
-msgid "home.hero.video_fallback"
-msgstr "Seu navegador não suporta a tag de vídeo."
-
-msgid "home.hero.title_html"
-msgstr "Site Tanssi <span class=\"shadow\">&lt;Dev&gt;</span>"
-
-msgid "home.hero.subtitle"
-msgstr ""
-"Construa, lance e escale redes Symbiotic mais rápido com a infraestrutura, "
-"as ferramentas e as integrações da Tanssi."
-
-msgid "home.hero.cards.launch.title"
-msgstr "Lance uma rede movida pela Tanssi"
-
-msgid "home.hero.cards.launch.description"
-msgstr "Obtenha ferramentas e guias para lançar sua rede em minutos."
-
-msgid "home.hero.cards.launch.button"
-msgstr "Começar"
-
-msgid "home.hero.cards.evm.title"
-msgstr "Desenvolva com ferramentas EVM"
-
-msgid "home.hero.cards.evm.description"
-msgstr ""
-"Aproveite as ferramentas EVM mais populares para acelerar seu "
-"desenvolvimento."
-
-msgid "home.hero.cards.evm.button"
-msgstr "Saiba mais"
-
-msgid "home.hero.cards.learn.title"
-msgstr "Explore conceitos técnicos"
-
-msgid "home.hero.cards.learn.description"
-msgstr ""
-"Conheça os recursos, os serviços e a segurança da Tanssi por meio da "
-"Symbiotic."
-
-msgid "home.hero.cards.learn.button"
-msgstr "Saiba mais"
-
-msgid "home.feature.heading.prefix"
-msgstr "O hub completo da Tanssi"
-
-msgid "home.feature.heading.accent"
-msgstr "Construtores"
-
-msgid "home.feature.description"
-msgstr ""
-"Explore mais maneiras de se engajar com o ecossistema Tanssi - obtenha "
-"financiamento, recursos e visibilidade para o seu projeto."
-
-msgid "home.feature.cards.one.badge"
-msgstr "Ecossistema"
-
-msgid "home.feature.cards.one.title"
-msgstr "Solicite um grant"
-
-msgid "home.feature.cards.one.arrow_alt"
-msgstr "Ir para a página Solicite um grant"
-
-msgid "home.feature.cards.two.badge"
-msgstr "Comece a construir"
-
-msgid "home.feature.cards.two.title"
-msgstr "Visite o TestNet"
-
-msgid "home.feature.cards.two.arrow_alt"
-msgstr "Ir para a página do TestNet"
-
-msgid "home.feature.cards.three.badge"
-msgstr "Insights do setor"
-
-msgid "home.feature.cards.three.title"
-msgstr "Atualizações do ecossistema"
-
-msgid "home.feature.cards.three.arrow_alt"
-msgstr "Ir para a página Atualizações do ecossistema"
-
-msgid "home.feature.separator_alt"
-msgstr "Design decorativo multicolorido da Tanssi"
-
-msgid "home.community.heading.prefix"
-msgstr "Junte-se à comunidade"
-
-msgid "home.community.heading.accent"
-msgstr "Dev"
-
-msgid "home.community.heading.suffix"
-msgstr "da Tanssi"
-
-msgid "home.community.buttons.discord"
-msgstr "Entrar no Discord"
-
-msgid "home.community.buttons.subscribe"
-msgstr "Assinar"
+"Generated-By: Babel 2.15.0\n"
 
 msgid "action.edit"
 msgstr "Editar esta página"
@@ -178,8 +25,23 @@ msgstr "Editar esta página"
 msgid "action.view"
 msgstr "Ver fonte"
 
-msgid "feedback.title"
-msgstr "Esta página foi útil?"
+msgid "disclaimer.third_party"
+msgstr "As informações apresentadas aqui foram fornecidas por terceiros e estão disponíveis apenas para fins informativos gerais. A Tanssi não endossa nenhum projeto listado e descrito no Site de Documentação da Tanssi (https://docs.tanssi.network/). A Tanssi Foundation não garante a precisão, integridade ou utilidade dessas informações. Qualquer confiança depositada nelas é de sua exclusiva responsabilidade. A Tanssi Foundation se exime de toda responsabilidade decorrente de qualquer confiança que você ou qualquer outra pessoa possa ter em qualquer parte deste conteúdo. Todas as declarações e/ou opiniões expressas nesses materiais são de responsabilidade exclusiva da pessoa ou entidade que as fornece e não representam necessariamente a opinião da Tanssi Foundation. As informações aqui não devem ser interpretadas como aconselhamento profissional ou financeiro de qualquer tipo. Sempre busque orientação de um profissional devidamente qualificado em relação a qualquer assunto ou circunstância em particular. As informações aqui podem conter links ou integração com outros sites operados ou conteúdo fornecido por terceiros, e tais sites podem apontar para este site. A Tanssi Foundation não tem controle sobre esses sites ou seu conteúdo e não terá responsabilidade decorrente ou relacionada a eles. A existência de qualquer link não constitui endosso desses sites, de seu conteúdo ou de seus operadores. Esses links são fornecidos apenas para sua conveniência, e você isenta e exonera a Tanssi Foundation de qualquer responsabilidade decorrente do uso dessas informações ou das informações fornecidas por qualquer site ou serviço de terceiros."
+
+msgid "error.404_title"
+msgstr "404 - Não encontrado"
+
+msgid "external_link_modal.cancel"
+msgstr "Cancelar"
+
+msgid "external_link_modal.continue"
+msgstr "Continuar para o site externo"
+
+msgid "external_link_modal.header"
+msgstr "Você está saindo do site de documentação da Tanssi"
+
+msgid "external_link_modal.message"
+msgstr "Uma nova aba será aberta e você será direcionado a um site independente de terceiros, que não é afiliado à Tanssi."
 
 msgid "feedback.ratings.helpful.name"
 msgstr "Esta página foi útil"
@@ -191,11 +53,119 @@ msgid "feedback.ratings.unhelpful.name"
 msgstr "Esta página pode ser aprimorada"
 
 msgid "feedback.ratings.unhelpful.note"
-msgstr ""
-"Obrigado pelo seu feedback! Ajude-nos a melhorar esta página enviando <a "
-"href=\"https://github.com/moondance-labs/tanssi-"
-"docs/issues/new/?title=[Feedback]+{title}+-+{url}\" target=\"_blank\" "
-"rel=\"noopener\">feedback adicional</a>."
+msgstr "Obrigado pelo seu feedback! Ajude-nos a melhorar esta página enviando <a href=\"https://github.com/moondance-labs/tanssi-docs/issues/new/?title=[Feedback]+{title}+-+{url}\" target=\"_blank\" rel=\"noopener\">feedback adicional</a>."
 
-msgid "home.feature.heading.suffix"
-msgstr "Tanssi"
+msgid "feedback.title"
+msgstr "Esta página foi útil?"
+
+msgid "footer.llms_full_label"
+msgstr "llms-full.txt"
+
+msgid "footer.made_with_html"
+msgstr "Feito com 🩵 por <a href=\"https://papermoon.io/\" target=\"_blank\">PaperMoon</a>"
+
+msgid "footer.material_attribution_html"
+msgstr "Feito com <a href=\"https://squidfunk.github.io/mkdocs-material/\" target=\"_blank\" rel=\"noopener\">Material for MkDocs</a>"
+
+msgid "footer.privacy_policy"
+msgstr "Política de privacidade"
+
+msgid "footer.terms_of_use"
+msgstr "Termos de uso"
+
+msgid "home.community.buttons.discord"
+msgstr "Entrar no Discord"
+
+msgid "home.community.buttons.subscribe"
+msgstr "Assinar"
+
+msgid "home.community.heading.accent"
+msgstr "Dev"
+
+msgid "home.community.heading.prefix"
+msgstr "Junte-se à comunidade"
+
+msgid "home.community.heading.suffix"
+msgstr "da Tanssi"
+
+msgid "home.feature.cards.one.arrow_alt"
+msgstr "Ir para a página Solicite um grant"
+
+msgid "home.feature.cards.one.badge"
+msgstr "Ecossistema"
+
+msgid "home.feature.cards.one.title"
+msgstr "Solicite um grant"
+
+msgid "home.feature.cards.three.arrow_alt"
+msgstr "Ir para a página Atualizações do ecossistema"
+
+msgid "home.feature.cards.three.badge"
+msgstr "Insights do setor"
+
+msgid "home.feature.cards.three.title"
+msgstr "Atualizações do ecossistema"
+
+msgid "home.feature.cards.two.arrow_alt"
+msgstr "Ir para a página do TestNet"
+
+msgid "home.feature.cards.two.badge"
+msgstr "Comece a construir"
+
+msgid "home.feature.cards.two.title"
+msgstr "Visite o TestNet"
+
+msgid "home.feature.description"
+msgstr "Explore mais maneiras de se engajar com o ecossistema Tanssi - obtenha financiamento, recursos e visibilidade para o seu projeto."
+
+msgid "home.feature.heading.accent"
+msgstr "Construtores"
+
+msgid "home.feature.heading.prefix"
+msgstr "O hub completo da Tanssi"
+
+msgid "home.feature.separator_alt"
+msgstr "Design decorativo multicolorido da Tanssi"
+
+msgid "home.hero.cards.evm.button"
+msgstr "Saiba mais"
+
+msgid "home.hero.cards.evm.description"
+msgstr "Aproveite as ferramentas EVM mais populares para acelerar seu desenvolvimento."
+
+msgid "home.hero.cards.evm.title"
+msgstr "Desenvolva com ferramentas EVM"
+
+msgid "home.hero.cards.launch.button"
+msgstr "Começar"
+
+msgid "home.hero.cards.launch.description"
+msgstr "Obtenha ferramentas e guias para lançar sua rede em minutos."
+
+msgid "home.hero.cards.launch.title"
+msgstr "Lance uma rede movida pela Tanssi"
+
+msgid "home.hero.cards.learn.button"
+msgstr "Saiba mais"
+
+msgid "home.hero.cards.learn.description"
+msgstr "Conheça os recursos, os serviços e a segurança da Tanssi por meio da Symbiotic."
+
+msgid "home.hero.cards.learn.title"
+msgstr "Explore conceitos técnicos"
+
+msgid "home.hero.subtitle"
+msgstr "Construa, lance e escale redes Symbiotic mais rápido com a infraestrutura, as ferramentas e as integrações da Tanssi."
+
+msgid "home.hero.title_html"
+msgstr "Site Tanssi <span class=\"shadow\">&lt;Dev&gt;</span>"
+
+msgid "home.hero.video_fallback"
+msgstr "Seu navegador não suporta a tag de vídeo."
+
+msgid "home.meta.title"
+msgstr "Tanssi Docs"
+
+msgid "meta.home_title"
+msgstr "Documentação da rede Tanssi"
+

--- a/i18n/pt/LC_MESSAGES/messages.po
+++ b/i18n/pt/LC_MESSAGES/messages.po
@@ -1,14 +1,14 @@
-# Portuguese translations for .
+# Portuguese translations for PROJECT.
 # Copyright (C) 2026 ORGANIZATION
-# This file is distributed under the same license as the  project.
+# This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version:  tanssi-docs\n"
+"Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-30 13:33-0500\n"
+"POT-Creation-Date: 2026-02-03 09:48-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: pt\n"

--- a/javascript/404-redirect.js
+++ b/javascript/404-redirect.js
@@ -1,0 +1,37 @@
+(function () {
+  var script = document.currentScript;
+  var redirectLocalesCsv =
+    (script && script.dataset && script.dataset.redirectLocales) || "";
+  var redirectLocales = redirectLocalesCsv
+    .split(",")
+    .map(function (value) {
+      return (value || "").trim().toLowerCase();
+    })
+    .filter(Boolean);
+  if (!redirectLocales.length) return;
+
+  // Site-agnostic base path (works under subpaths like GitHub Pages /<repo>/).
+  var basePath = "/";
+  try {
+    basePath = new URL(document.baseURI).pathname || "/";
+  } catch (e) {}
+  if (basePath.charAt(0) !== "/") basePath = "/" + basePath;
+  if (!basePath.endsWith("/")) basePath += "/";
+
+  var pathname = window.location.pathname || "/";
+  var rel = pathname;
+  if (basePath !== "/" && rel.indexOf(basePath) === 0) {
+    rel = rel.slice(basePath.length);
+  } else if (rel.indexOf("/") === 0) {
+    rel = rel.slice(1);
+  }
+
+  var first = (rel.split("/").filter(Boolean)[0] || "").toLowerCase();
+  if (redirectLocales.indexOf(first) === -1) return;
+
+  // Avoid redirect loops.
+  var target = (basePath + first + "/404/").replace(/\/{2,}/g, "/");
+  if (pathname === target || pathname.indexOf(target) === 0) return;
+
+  window.location.replace(target);
+})();

--- a/pt/.nav.yml
+++ b/pt/.nav.yml
@@ -6,6 +6,6 @@ nav:
   - 'Aprender': pt/learn
   - 'Recursos de IA': pt/ai-resources
   - 'Sobre':
-    - 'Sobre Tanssi': https://www.tanssi.network
-    - 'TestNet da Tanssi': https://apps.tanssi.network
+    - 'Sobre Tanssi': https://www.tanssi.network/
+    - 'TestNet da Tanssi': https://apps.tanssi.network/create
 

--- a/pt/.nav.yml
+++ b/pt/.nav.yml
@@ -1,9 +1,11 @@
 nav:
-    - index.md
-    - pt/builders
-    - pt/node-operators
-    - pt/learn
-    - pt/ai-resources
-    - Sobre:
-        - 'Sobre Tanssi': https://www.tanssi.network/
-        - 'TestNet da Tanssi': https://apps.tanssi.network/create
+  - index.md
+  - 404.md
+  - 'Builders': pt/builders
+  - 'Node Operators': pt/node-operators
+  - 'Aprender': pt/learn
+  - 'Recursos de IA': pt/ai-resources
+  - 'Sobre':
+    - 'Sobre Tanssi': https://www.tanssi.network
+    - 'TestNet da Tanssi': https://apps.tanssi.network
+

--- a/pt/404.md
+++ b/pt/404.md
@@ -1,0 +1,8 @@
+---
+template: 404.html
+hide:
+  - navigation
+  - toc
+search:
+  exclude: true
+---


### PR DESCRIPTION
### Description

- Added a Portuguese 404 content page that uses the shared 404 template, hides the left navigation and table of contents, and is excluded from search.
- Added a minimal 404 redirect script that reads supported locales from the page (no hard-coded languages), detects locale prefixes in the URL, redirects to the locale-specific 404 page, supports subpath hosting, and avoids redirect loops.
- Automated babbel files

Related to mkdocs [PR-101](https://github.com/papermoonio/tanssi-mkdocs/pull/101)

### Checklist

- [ ] I have added a label to this PR 🏷️
- [ ] I have run my changes through Grammarly
- [ ] If this page requires a disclaimer, I have added one
- [ ] If pages have been moved around, I have created an additional PR in `tanssi-mkdocs` to update redirects